### PR TITLE
Add Health Product Recommender Lite plugin

### DIFF
--- a/health-product-recommender-lite/assets/css/style.css
+++ b/health-product-recommender-lite/assets/css/style.css
@@ -1,0 +1,6 @@
+#hprl-quiz{max-width:600px;margin:0 auto;font-family:Arial, sans-serif;}
+#hprl-quiz label{display:block;margin-bottom:10px;}
+#hprl-quiz input{width:100%;padding:8px;box-sizing:border-box;}
+#hprl-quiz button{padding:10px 20px;margin-top:10px;cursor:pointer;}
+.hprl-products{display:flex;gap:10px;flex-wrap:wrap;}
+@media(max-width:600px){.hprl-products{flex-direction:column;}}

--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -1,0 +1,39 @@
+document.addEventListener('DOMContentLoaded', function(){
+  const quiz = document.getElementById('hprl-quiz');
+  if(!quiz) return;
+  const steps = quiz.querySelectorAll('.hprl-step');
+  const next1 = document.getElementById('hprl-next1');
+  const next2 = document.getElementById('hprl-next2');
+  next1.addEventListener('click', function(){
+    if(document.getElementById('hprl-name').value && document.getElementById('hprl-email').value && document.getElementById('hprl-phone').value && document.getElementById('hprl-year').value){
+      steps[0].style.display='none';
+      steps[1].style.display='block';
+    }
+  });
+  next2.addEventListener('click', function(){
+    steps[1].style.display='none';
+    steps[2].style.display='block';
+  });
+  quiz.querySelectorAll('.hprl-select').forEach(btn=>{
+    btn.addEventListener('click', function(){
+      const data = new FormData();
+      data.append('action','hprl_save_quiz');
+      data.append('nonce', hprlData.nonce);
+      data.append('name', document.getElementById('hprl-name').value);
+      data.append('email', document.getElementById('hprl-email').value);
+      data.append('phone', document.getElementById('hprl-phone').value);
+      data.append('birth_year', document.getElementById('hprl-year').value);
+      data.append('location', document.getElementById('hprl-location').value);
+      let answers=[];
+      quiz.querySelectorAll('.hprl-question').forEach(q=>{answers.push(q.value);});
+      answers.forEach(a=>data.append('answers[]',a));
+      data.append('product', this.dataset.product);
+      fetch(hprlData.ajaxurl, {method:'POST', body:data, credentials:'same-origin'})
+        .then(r=>r.json())
+        .then(()=>{
+          fetch(hprlData.cart_url+'?add-to-cart='+this.dataset.product,{credentials:'same-origin'})
+            .then(()=>{window.location=hprlData.checkout;});
+        });
+    });
+  });
+});

--- a/health-product-recommender-lite/health-product-recommender-lite.php
+++ b/health-product-recommender-lite/health-product-recommender-lite.php
@@ -1,0 +1,52 @@
+<?php
+/*
+Plugin Name: Health Product Recommender Lite
+Plugin URI: https://beohosting.com/plugins/health-product-recommender-lite
+Description: Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnovu zdravstvenog upitnika, potpuno kompatibilan sa Woodmart temom i Elementorom.
+Version: 1.0
+Author: BeoHosting
+Author URI: https://beohosting.com
+License: GPL2+
+*/
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+define( 'HPRL_DIR', plugin_dir_path( __FILE__ ) );
+define( 'HPRL_URL', plugin_dir_url( __FILE__ ) );
+
+define( 'HPRL_TABLE', $GLOBALS['wpdb']->prefix . 'health_quiz_results' );
+
+register_activation_hook( __FILE__, 'hprl_activate' );
+function hprl_activate() {
+    global $wpdb;
+    $charset_collate = $wpdb->get_charset_collate();
+    $sql = "CREATE TABLE IF NOT EXISTS " . HPRL_TABLE . " (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        name varchar(200) NOT NULL,
+        email varchar(200) NOT NULL,
+        phone varchar(100) NOT NULL,
+        birth_year int(4) NOT NULL,
+        location varchar(200) DEFAULT '',
+        answers text NOT NULL,
+        product_id bigint(20) NOT NULL,
+        created_at datetime NOT NULL,
+        PRIMARY KEY (id)
+    ) $charset_collate";
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    dbDelta( $sql );
+}
+
+register_uninstall_hook( __FILE__, 'hprl_uninstall' );
+function hprl_uninstall() {
+    global $wpdb;
+    $wpdb->query( "DROP TABLE IF EXISTS " . HPRL_TABLE );
+    delete_option( 'hprl_questions' );
+    delete_option( 'hprl_products' );
+}
+
+// Includes
+require_once HPRL_DIR . 'includes/data-handler.php';
+require_once HPRL_DIR . 'includes/shortcodes.php';
+if ( is_admin() ) {
+    require_once HPRL_DIR . 'includes/admin-panel.php';
+}

--- a/health-product-recommender-lite/includes/admin-panel.php
+++ b/health-product-recommender-lite/includes/admin-panel.php
@@ -1,0 +1,101 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+add_action( 'admin_menu', 'hprl_admin_menu' );
+function hprl_admin_menu() {
+    add_menu_page( 'Health Quiz', 'Health Quiz', 'manage_options', 'hprl-questions', 'hprl_questions_page', 'dashicons-heart' );
+    add_submenu_page( 'hprl-questions', 'Pitanja', 'Pitanja', 'manage_options', 'hprl-questions', 'hprl_questions_page' );
+    add_submenu_page( 'hprl-questions', 'Rezultati', 'Rezultati', 'manage_options', 'hprl-results', 'hprl_results_page' );
+}
+
+function hprl_questions_page() {
+    if ( isset( $_POST['hprl_save_questions'] ) ) {
+        check_admin_referer( 'hprl_save_questions' );
+        $questions = array();
+        for ( $i = 0; $i < 4; $i++ ) {
+            $questions[$i] = sanitize_text_field( $_POST['question'][$i] );
+        }
+        update_option( 'hprl_questions', $questions );
+        $products['cheap'] = intval( $_POST['cheap_product'] );
+        $products['premium'] = intval( $_POST['premium_product'] );
+        update_option( 'hprl_products', $products );
+        echo '<div class="updated"><p>Sačuvano.</p></div>';
+    }
+    $questions = get_option( 'hprl_questions', array(
+        'Koliko cesto osecate umor?',
+        'Da li imate problema sa varenjem?',
+        'Koliko sati spavate?',
+        'Da li osecate stres?'
+    ) );
+    $products = get_option( 'hprl_products', array( 'cheap' => '', 'premium' => '' ) );
+    ?>
+    <div class="wrap">
+        <h1>Pitanja</h1>
+        <form method="post">
+            <?php wp_nonce_field( 'hprl_save_questions' ); ?>
+            <table class="form-table">
+                <?php foreach ( $questions as $idx => $q ) : ?>
+                <tr>
+                    <th>Pitanje <?php echo $idx+1; ?></th>
+                    <td><input type="text" name="question[<?php echo $idx; ?>]" value="<?php echo esc_attr( $q ); ?>" class="regular-text" required></td>
+                </tr>
+                <?php endforeach; ?>
+                <tr>
+                    <th>ID jeftinijeg proizvoda</th>
+                    <td><input type="number" name="cheap_product" value="<?php echo esc_attr( $products['cheap'] ); ?>" class="small-text" required></td>
+                </tr>
+                <tr>
+                    <th>ID skupljeg proizvoda</th>
+                    <td><input type="number" name="premium_product" value="<?php echo esc_attr( $products['premium'] ); ?>" class="small-text" required></td>
+                </tr>
+            </table>
+            <p><input type="submit" name="hprl_save_questions" class="button-primary" value="Sačuvaj"></p>
+        </form>
+    </div>
+    <?php
+}
+
+function hprl_results_page() {
+    global $wpdb;
+    if ( isset( $_GET['export'] ) ) {
+        $rows = $wpdb->get_results( "SELECT * FROM " . HPRL_TABLE . " ORDER BY created_at DESC", ARRAY_A );
+        header('Content-Type: text/csv');
+        header('Content-Disposition: attachment; filename="hprl-results.csv"');
+        $out = fopen('php://output', 'w');
+        fputcsv( $out, array('ID','Name','Email','Phone','Birth Year','Location','Answers','Product ID','Date') );
+        foreach ( $rows as $row ) {
+            fputcsv( $out, $row );
+        }
+        fclose($out);
+        exit;
+    }
+    $results = $wpdb->get_results( "SELECT * FROM " . HPRL_TABLE . " ORDER BY created_at DESC" );
+    ?>
+    <div class="wrap">
+        <h1>Rezultati</h1>
+        <p><a href="?page=hprl-results&export=1" class="button">Export CSV</a></p>
+        <table class="widefat">
+            <thead>
+            <tr>
+                <th>ID</th><th>Ime</th><th>Email</th><th>Telefon</th><th>Godina</th><th>Mesto</th><th>Odgovori</th><th>Proizvod</th><th>Datum</th>
+            </tr>
+            </thead>
+            <tbody>
+            <?php foreach ( $results as $row ) : ?>
+                <tr>
+                    <td><?php echo esc_html( $row->id ); ?></td>
+                    <td><?php echo esc_html( $row->name ); ?></td>
+                    <td><?php echo esc_html( $row->email ); ?></td>
+                    <td><?php echo esc_html( $row->phone ); ?></td>
+                    <td><?php echo esc_html( $row->birth_year ); ?></td>
+                    <td><?php echo esc_html( $row->location ); ?></td>
+                    <td><?php echo esc_html( implode( ',', maybe_unserialize( $row->answers ) ) ); ?></td>
+                    <td><?php echo esc_html( $row->product_id ); ?></td>
+                    <td><?php echo esc_html( $row->created_at ); ?></td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <?php
+}

--- a/health-product-recommender-lite/includes/data-handler.php
+++ b/health-product-recommender-lite/includes/data-handler.php
@@ -1,0 +1,29 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+add_action( 'wp_ajax_hprl_save_quiz', 'hprl_save_quiz' );
+add_action( 'wp_ajax_nopriv_hprl_save_quiz', 'hprl_save_quiz' );
+function hprl_save_quiz() {
+    check_ajax_referer( 'hprl_nonce', 'nonce' );
+    global $wpdb;
+    $name = sanitize_text_field( $_POST['name'] );
+    $email = sanitize_email( $_POST['email'] );
+    $phone = sanitize_text_field( $_POST['phone'] );
+    $birth_year = intval( $_POST['birth_year'] );
+    $location = sanitize_text_field( $_POST['location'] );
+    $answers = isset( $_POST['answers'] ) ? array_map( 'sanitize_text_field', $_POST['answers'] ) : array();
+    $product_id = intval( $_POST['product'] );
+
+    $wpdb->insert( HPRL_TABLE, [
+        'name' => $name,
+        'email' => $email,
+        'phone' => $phone,
+        'birth_year' => $birth_year,
+        'location' => $location,
+        'answers' => maybe_serialize( $answers ),
+        'product_id' => $product_id,
+        'created_at' => current_time( 'mysql' )
+    ] );
+
+    wp_send_json_success();
+}

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -1,0 +1,53 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+add_shortcode( 'health_quiz', 'hprl_quiz_shortcode' );
+function hprl_quiz_shortcode() {
+    $questions = get_option( 'hprl_questions', array(
+        'Koliko cesto osecate umor?',
+        'Da li imate problema sa varenjem?',
+        'Koliko sati spavate?',
+        'Da li osecate stres?'
+    ) );
+    $products = get_option( 'hprl_products', array( 'cheap' => '', 'premium' => '' ) );
+
+    ob_start();
+    ?>
+    <div id="hprl-quiz">
+        <div class="hprl-step" data-step="1">
+            <label>Ime i prezime*<br><input type="text" id="hprl-name" required></label>
+            <label>Email*<br><input type="email" id="hprl-email" required></label>
+            <label>Telefon*<br><input type="text" id="hprl-phone" required></label>
+            <label>Godina rodjenja*<br><input type="number" id="hprl-year" required></label>
+            <label>Mesto stanovanja<br><input type="text" id="hprl-location"></label>
+            <button id="hprl-next1">Dalje</button>
+        </div>
+        <div class="hprl-step" data-step="2" style="display:none;">
+            <?php foreach ( $questions as $idx => $q ) : ?>
+                <label><?php echo esc_html( $q ); ?><br>
+                    <input type="text" class="hprl-question" data-index="<?php echo $idx; ?>">
+                </label>
+            <?php endforeach; ?>
+            <button id="hprl-next2">Dalje</button>
+        </div>
+        <div class="hprl-step" data-step="3" style="display:none;">
+            <p>Preporucujemo sledece proizvode:</p>
+            <div class="hprl-products">
+                <button class="hprl-select" data-product="<?php echo esc_attr( $products['cheap'] ); ?>">Jeftiniji paket</button>
+                <button class="hprl-select" data-product="<?php echo esc_attr( $products['premium'] ); ?>">Skuplji paket</button>
+            </div>
+        </div>
+    </div>
+    <?php
+    wp_enqueue_style( 'hprl-style', HPRL_URL . 'assets/css/style.css', array(), '1.0' );
+    wp_enqueue_script( 'hprl-script', HPRL_URL . 'assets/js/script.js', array(), '1.0', true );
+    wp_localize_script( 'hprl-script', 'hprlData', array(
+        'ajaxurl' => admin_url( 'admin-ajax.php' ),
+        'nonce'   => wp_create_nonce( 'hprl_nonce' ),
+        'cheap'   => $products['cheap'],
+        'premium' => $products['premium'],
+        'checkout'=> wc_get_checkout_url(),
+        'cart_url'=> wc_get_cart_url()
+    ) );
+    return ob_get_clean();
+}

--- a/health-product-recommender-lite/readme.txt
+++ b/health-product-recommender-lite/readme.txt
@@ -1,0 +1,10 @@
+=== Health Product Recommender Lite ===
+Contributors: BeoHosting
+Tags: quiz, health, recommendations
+Requires at least: 6.0
+Tested up to: 6.5
+Stable tag: 1.0
+License: GPL2+
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnovu zdravstvenog upitnika.

--- a/health-product-recommender-lite/uninstall.php
+++ b/health-product-recommender-lite/uninstall.php
@@ -1,0 +1,8 @@
+<?php
+if( !defined( 'WP_UNINSTALL_PLUGIN' ) ) exit();
+
+global $wpdb;
+$wpdb->query( "DROP TABLE IF EXISTS " . $wpdb->prefix . 'health_quiz_results' );
+
+delete_option( 'hprl_questions' );
+delete_option( 'hprl_products' );


### PR DESCRIPTION
## Summary
- add lightweight WordPress plugin `health-product-recommender-lite`
- implement shortcode with AJAX quiz and product selection
- add admin pages for editing questions and viewing results
- store quiz data in custom table
- include uninstall cleanup and responsive styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6841d0509b488322b9e8d0c3936a3e8d