### PR TITLE
Add predefined answers and combo logic

### DIFF
--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -11,6 +11,23 @@ document.addEventListener('DOMContentLoaded', function(){
     }
   });
   next2.addEventListener('click', function(){
+    let valid=true;
+    const indexes=[];
+    quiz.querySelectorAll('.hprl-question-group').forEach(g=>{
+      const sel=g.querySelector('input:checked');
+      if(!sel){valid=false;return;}
+      indexes.push(sel.dataset.index);
+    });
+    if(!valid) return;
+    let cheap=hprlData.cheap;
+    let premium=hprlData.premium;
+    const key=indexes.join('|');
+    if(hprlData.combos && hprlData.combos[key]){
+      cheap=hprlData.combos[key].cheap;
+      premium=hprlData.combos[key].premium;
+    }
+    quiz.querySelector('.hprl-select[data-type="cheap"]').dataset.product=cheap;
+    quiz.querySelector('.hprl-select[data-type="premium"]').dataset.product=premium;
     steps[1].style.display='none';
     steps[2].style.display='block';
   });
@@ -25,7 +42,10 @@ document.addEventListener('DOMContentLoaded', function(){
       data.append('birth_year', document.getElementById('hprl-year').value);
       data.append('location', document.getElementById('hprl-location').value);
       let answers=[];
-      quiz.querySelectorAll('.hprl-question').forEach(q=>{answers.push(q.value);});
+      quiz.querySelectorAll('.hprl-question-group').forEach(g=>{
+        const sel=g.querySelector('input:checked');
+        if(sel) answers.push(sel.value);
+      });
       answers.forEach(a=>data.append('answers[]',a));
       data.append('product', this.dataset.product);
       fetch(hprlData.ajaxurl, {method:'POST', body:data, credentials:'same-origin'})

--- a/health-product-recommender-lite/health-product-recommender-lite.php
+++ b/health-product-recommender-lite/health-product-recommender-lite.php
@@ -3,7 +3,7 @@
 Plugin Name: Health Product Recommender Lite
 Plugin URI: https://beohosting.com/plugins/health-product-recommender-lite
 Description: Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnovu zdravstvenog upitnika, potpuno kompatibilan sa Woodmart temom i Elementorom.
-Version: 1.0
+Version: 1.1
 Author: BeoHosting
 Author URI: https://beohosting.com
 License: GPL2+
@@ -42,6 +42,7 @@ function hprl_uninstall() {
     $wpdb->query( "DROP TABLE IF EXISTS " . HPRL_TABLE );
     delete_option( 'hprl_questions' );
     delete_option( 'hprl_products' );
+    delete_option( 'hprl_combos' );
 }
 
 // Includes


### PR DESCRIPTION
## Summary
- enable uninstalling combos option
- add dynamic questions with predefined answers in admin panel
- support product recommendation combos
- update shortcode rendering
- enhance JS logic for combos

## Testing
- `node -v`
- *No PHP runtime available for further testing*

------
https://chatgpt.com/codex/tasks/task_b_6841d201957883229ab61e520bc83866