### PR TITLE
Enable automatic answer combos

### DIFF
--- a/health-product-recommender-lite/health-product-recommender-lite.php
+++ b/health-product-recommender-lite/health-product-recommender-lite.php
@@ -3,7 +3,7 @@
 Plugin Name: Health Product Recommender Lite
 Plugin URI: https://beohosting.com/plugins/health-product-recommender-lite
 Description: Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnovu zdravstvenog upitnika, potpuno kompatibilan sa Woodmart temom i Elementorom.
-Version: 1.1
+Version: 1.2
 Author: BeoHosting
 Author URI: https://beohosting.com
 License: GPL2+
@@ -46,6 +46,7 @@ function hprl_uninstall() {
 }
 
 // Includes
+require_once HPRL_DIR . 'includes/utils.php';
 require_once HPRL_DIR . 'includes/data-handler.php';
 require_once HPRL_DIR . 'includes/shortcodes.php';
 if ( is_admin() ) {

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -12,7 +12,15 @@ function hprl_quiz_shortcode() {
     $combos    = get_option( 'hprl_combos', array() );
     $combos_out = array();
     foreach ( $combos as $c ) {
-        if ( ! empty( $c['answers'] ) ) {
+        if ( empty( $c['answers'] ) ) {
+            continue;
+        }
+        if ( is_array( $c['answers'] ) ) {
+            $keys = hprl_cartesian_product( array_map( function( $v ) { return (array) $v; }, $c['answers'] ) );
+            foreach ( $keys as $k ) {
+                $combos_out[ implode( '|', $k ) ] = array( 'cheap' => $c['cheap'], 'premium' => $c['premium'] );
+            }
+        } else {
             $combos_out[ $c['answers'] ] = array( 'cheap' => $c['cheap'], 'premium' => $c['premium'] );
         }
     }

--- a/health-product-recommender-lite/includes/utils.php
+++ b/health-product-recommender-lite/includes/utils.php
@@ -1,0 +1,37 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+function hprl_cartesian_product($arrays) {
+    $result = array(array());
+    foreach ($arrays as $property => $values) {
+        $tmp = array();
+        foreach ($result as $result_item) {
+            foreach ($values as $value) {
+                $tmp[] = array_merge($result_item, array($value));
+            }
+        }
+        $result = $tmp;
+    }
+    return $result;
+}
+
+function hprl_generate_all_combos($questions) {
+    $choices = array();
+    foreach ($questions as $q) {
+        if (!empty($q['answers'])) {
+            $choices[] = array_keys($q['answers']);
+        } else {
+            $choices[] = array('');
+        }
+    }
+    $perms = hprl_cartesian_product($choices);
+    $combos = array();
+    foreach ($perms as $p) {
+        $answers = array();
+        foreach ($p as $idx) {
+            $answers[] = array($idx);
+        }
+        $combos[] = array('answers' => $answers, 'cheap' => '', 'premium' => '');
+    }
+    return $combos;
+}


### PR DESCRIPTION
## Summary
- include new utility helpers
- auto-generate answer combinations and allow multiple answers
- expose the new combinations in the shortcode
- update plugin version to `1.2`

## Testing
- `php -l health-product-recommender-lite/includes/utils.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841d67e3efc832282460a2fc8fd608f