### PR TITLE
Add question pagination and save answers early

### DIFF
--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -1,63 +1,75 @@
-document.addEventListener('DOMContentLoaded', function(){
-  const quiz = document.getElementById('hprl-quiz');
+document.addEventListener('DOMContentLoaded',function(){
+  const quiz=document.getElementById('hprl-quiz');
   if(!quiz) return;
-  const steps = quiz.querySelectorAll('.hprl-step');
-  const next1 = document.getElementById('hprl-next1');
-  const next2 = document.getElementById('hprl-next2');
-  next1.addEventListener('click', function(){
-    if(document.getElementById('hprl-name').value && document.getElementById('hprl-email').value && document.getElementById('hprl-phone').value && document.getElementById('hprl-year').value){
-      steps[0].style.display='none';
-      steps[1].style.display='block';
-    }
-  });
-  next2.addEventListener('click', function(){
-    let valid=true;
+  const steps=Array.from(quiz.querySelectorAll('.hprl-step'));
+  let resultId=null;
+  function showStep(index){
+    steps.forEach((s,i)=>{s.style.display=i===index?'block':'none';});
+  }
+  function gatherIndexes(){
     const indexes=[];
     quiz.querySelectorAll('.hprl-question-group').forEach(g=>{
       const sel=g.querySelector('input:checked');
-      if(!sel){valid=false;return;}
-      indexes.push(sel.dataset.index);
+      if(sel) indexes.push(sel.dataset.index);
     });
-    if(!valid) return;
-    let cheap=hprlData.cheap;
-    let premium=hprlData.premium;
-    const key=indexes.join('|');
-    if(hprlData.combos && hprlData.combos[key]){
-      cheap=hprlData.combos[key].cheap;
-      premium=hprlData.combos[key].premium;
-    }
-    quiz.querySelector('.hprl-select[data-type="cheap"]').dataset.product=cheap;
-    quiz.querySelector('.hprl-select[data-type="premium"]').dataset.product=premium;
-    steps[1].style.display='none';
-    steps[2].style.display='block';
+    return indexes;
+  }
+  function gatherAnswers(){
+    const ans=[];
+    quiz.querySelectorAll('.hprl-question-group').forEach(g=>{
+      const sel=g.querySelector('input:checked');
+      if(sel) ans.push(sel.value);
+    });
+    return ans;
+  }
+  quiz.querySelectorAll('.hprl-next').forEach(btn=>{
+    btn.addEventListener('click',function(){
+      const stepElem=this.closest('.hprl-step');
+      const step=parseInt(stepElem.dataset.step);
+      if(step===1){
+        if(!(document.getElementById('hprl-name').value&&document.getElementById('hprl-email').value&&document.getElementById('hprl-phone').value&&document.getElementById('hprl-year').value))return;
+      }else{
+        let valid=true;
+        stepElem.querySelectorAll('.hprl-question-group').forEach(g=>{if(!g.querySelector('input:checked'))valid=false;});
+        if(!valid)return;
+      }
+      const next=step+1;
+      if(next===steps.length){
+        const indexes=gatherIndexes();
+        let cheap=hprlData.cheap;
+        let premium=hprlData.premium;
+        const key=indexes.join('|');
+        if(hprlData.combos&&hprlData.combos[key]){
+          cheap=hprlData.combos[key].cheap;
+          premium=hprlData.combos[key].premium;
+        }
+        quiz.querySelector('.hprl-select[data-type="cheap"]').dataset.product=cheap;
+        quiz.querySelector('.hprl-select[data-type="premium"]').dataset.product=premium;
+        const data=new FormData();
+        data.append('action','hprl_save_answers');
+        data.append('nonce',hprlData.nonce);
+        data.append('name',document.getElementById('hprl-name').value);
+        data.append('email',document.getElementById('hprl-email').value);
+        data.append('phone',document.getElementById('hprl-phone').value);
+        data.append('birth_year',document.getElementById('hprl-year').value);
+        data.append('location',document.getElementById('hprl-location').value);
+        gatherAnswers().forEach(a=>data.append('answers[]',a));
+        fetch(hprlData.ajaxurl,{method:'POST',body:data,credentials:'same-origin'})
+          .then(r=>r.json()).then(res=>{if(res.success)resultId=res.data.result_id;});
+      }
+      showStep(next-1);
+    });
   });
   quiz.querySelectorAll('.hprl-select').forEach(btn=>{
-    btn.addEventListener('click', function(){
-      const data = new FormData();
-      data.append('action','hprl_save_quiz');
-      data.append('nonce', hprlData.nonce);
-      data.append('name', document.getElementById('hprl-name').value);
-      data.append('email', document.getElementById('hprl-email').value);
-      data.append('phone', document.getElementById('hprl-phone').value);
-      data.append('birth_year', document.getElementById('hprl-year').value);
-      data.append('location', document.getElementById('hprl-location').value);
-      let answers=[];
-      quiz.querySelectorAll('.hprl-question-group').forEach(g=>{
-        const sel=g.querySelector('input:checked');
-        if(sel) answers.push(sel.value);
-      });
-      answers.forEach(a=>data.append('answers[]',a));
-      data.append('product', this.dataset.product);
-      fetch(hprlData.ajaxurl, {method:'POST', body:data, credentials:'same-origin'})
-        .then(r=>r.json())
-        .then(res=>{
-          if(!res.success){
-            alert(res.data && res.data.message ? res.data.message : 'Doslo je do greske');
-            return;
-          }
-          fetch(hprlData.cart_url+'?add-to-cart='+this.dataset.product,{credentials:'same-origin'})
-            .then(()=>{window.location=hprlData.checkout;});
-        });
+    btn.addEventListener('click',function(){
+      const data=new FormData();
+      data.append('action','hprl_set_product');
+      data.append('nonce',hprlData.nonce);
+      data.append('result_id',resultId||0);
+      data.append('product',this.dataset.product);
+      fetch(hprlData.ajaxurl,{method:'POST',body:data,credentials:'same-origin'})
+        .then(()=>{fetch(hprlData.cart_url+'?add-to-cart='+this.dataset.product,{credentials:'same-origin'}).then(()=>{window.location=hprlData.checkout;});});
     });
   });
+  showStep(0);
 });

--- a/health-product-recommender-lite/includes/admin-panel.php
+++ b/health-product-recommender-lite/includes/admin-panel.php
@@ -29,6 +29,9 @@ function hprl_questions_page() {
         update_option( 'hprl_questions', $questions );
         $max_q = count( $questions );
 
+        $per_page = max( 1, intval( $_POST['questions_per_page'] ) );
+        update_option( 'hprl_questions_per_page', $per_page );
+
         $products['cheap']   = intval( $_POST['cheap_product'] );
         $products['premium'] = intval( $_POST['premium_product'] );
         update_option( 'hprl_products', $products );
@@ -69,6 +72,7 @@ function hprl_questions_page() {
     $questions = get_option( 'hprl_questions', $default_questions );
     $products  = get_option( 'hprl_products', array( 'cheap' => '', 'premium' => '' ) );
     $combos    = get_option( 'hprl_combos', array() );
+    $per_page  = intval( get_option( 'hprl_questions_per_page', 3 ) );
     $max_q = count( $questions );
     foreach ( $combos as &$c ) {
         if ( ! is_array( $c['answers'] ) ) {
@@ -115,6 +119,10 @@ function hprl_questions_page() {
                 <?php endfor; ?>
                 </tbody>
                 <tbody>
+            <tr>
+                <th>Broj pitanja po stranici</th>
+                <td><input type="number" name="questions_per_page" value="<?php echo esc_attr( $per_page ); ?>" min="1" class="small-text" /></td>
+            </tr>
             <tr>
                 <th>ID jeftinijeg proizvoda (podrazumevano)</th>
                 <td>

--- a/health-product-recommender-lite/includes/data-handler.php
+++ b/health-product-recommender-lite/includes/data-handler.php
@@ -33,3 +33,49 @@ function hprl_save_quiz() {
 
     wp_send_json_success();
 }
+
+add_action( 'wp_ajax_hprl_save_answers', 'hprl_save_answers' );
+add_action( 'wp_ajax_nopriv_hprl_save_answers', 'hprl_save_answers' );
+function hprl_save_answers() {
+    check_ajax_referer( 'hprl_nonce', 'nonce' );
+    global $wpdb;
+    $name = sanitize_text_field( $_POST['name'] );
+    $email = sanitize_email( $_POST['email'] );
+    if ( ! is_email( $email ) ) {
+        wp_send_json_error( array( 'message' => 'Neispravan email.' ) );
+    }
+    $phone = preg_replace( '/[^0-9]/', '', $_POST['phone'] );
+    if ( $phone === '' ) {
+        wp_send_json_error( array( 'message' => 'Neispravan telefon.' ) );
+    }
+    $birth_year = intval( $_POST['birth_year'] );
+    $location = sanitize_text_field( $_POST['location'] );
+    $answers = isset( $_POST['answers'] ) ? array_map( 'sanitize_text_field', $_POST['answers'] ) : array();
+
+    $wpdb->insert( HPRL_TABLE, [
+        'name' => $name,
+        'email' => $email,
+        'phone' => $phone,
+        'birth_year' => $birth_year,
+        'location' => $location,
+        'answers' => maybe_serialize( $answers ),
+        'product_id' => 0,
+        'created_at' => current_time( 'mysql' )
+    ] );
+
+    wp_send_json_success( array( 'result_id' => $wpdb->insert_id ) );
+}
+
+add_action( 'wp_ajax_hprl_set_product', 'hprl_set_product' );
+add_action( 'wp_ajax_nopriv_hprl_set_product', 'hprl_set_product' );
+function hprl_set_product() {
+    check_ajax_referer( 'hprl_nonce', 'nonce' );
+    global $wpdb;
+    $id = intval( $_POST['result_id'] );
+    $product_id = intval( $_POST['product'] );
+    if ( $id > 0 ) {
+        $wpdb->update( HPRL_TABLE, [ 'product_id' => $product_id ], [ 'id' => $id ] );
+        wp_send_json_success();
+    }
+    wp_send_json_error();
+}

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -10,6 +10,9 @@ function hprl_quiz_shortcode() {
     $questions = get_option( 'hprl_questions', $default_questions );
     $products  = get_option( 'hprl_products', array( 'cheap' => '', 'premium' => '' ) );
     $combos    = get_option( 'hprl_combos', array() );
+    $per_page  = intval( get_option( 'hprl_questions_per_page', 3 ) );
+    if ( $per_page < 1 ) $per_page = 1;
+    $question_pages = array_chunk( $questions, $per_page );
     $combos_out = array();
     foreach ( $combos as $c ) {
         if ( empty( $c['answers'] ) ) {
@@ -28,29 +31,32 @@ function hprl_quiz_shortcode() {
     ob_start();
     ?>
     <div id="hprl-quiz">
-        <div class="hprl-step" data-step="1">
+        <?php $step = 1; ?>
+        <div class="hprl-step" data-step="<?php echo $step; ?>">
             <label>Ime i prezime*<br><input type="text" id="hprl-name" required></label>
             <label>Email*<br><input type="email" id="hprl-email" required></label>
             <label>Telefon*<br><input type="tel" id="hprl-phone" pattern="[0-9]+" title="Samo brojevi" required></label>
             <label>Godina rodjenja*<br><input type="number" id="hprl-year" required></label>
             <label>Mesto stanovanja<br><input type="text" id="hprl-location"></label>
-            <button id="hprl-next1">Dalje</button>
+            <button class="hprl-next">Dalje</button>
         </div>
-        <div class="hprl-step" data-step="2" style="display:none;">
-            <?php foreach ( $questions as $idx => $q ) : ?>
-                <div class="hprl-question-group" data-question="<?php echo $idx; ?>">
+        <?php $q_index = 0; foreach ( $question_pages as $p_idx => $page ) : $step++; ?>
+        <div class="hprl-step" data-step="<?php echo $step; ?>" style="display:none;">
+            <?php foreach ( $page as $q ) : ?>
+                <div class="hprl-question-group" data-question="<?php echo $q_index; ?>">
                     <p><?php echo esc_html( $q['text'] ); ?></p>
                     <?php foreach ( $q['answers'] as $a_idx => $ans ) : ?>
                         <label>
-                            <input type="radio" name="q<?php echo $idx; ?>" class="hprl-question" data-index="<?php echo $a_idx; ?>" value="<?php echo esc_attr( $ans ); ?>" required>
+                            <input type="radio" name="q<?php echo $q_index; ?>" class="hprl-question" data-index="<?php echo $a_idx; ?>" value="<?php echo esc_attr( $ans ); ?>" required>
                             <?php echo esc_html( $ans ); ?>
                         </label>
                     <?php endforeach; ?>
                 </div>
-            <?php endforeach; ?>
-            <button id="hprl-next2">Dalje</button>
+            <?php $q_index++; endforeach; ?>
+            <button class="hprl-next">Dalje</button>
         </div>
-        <div class="hprl-step" data-step="3" style="display:none;">
+        <?php endforeach; $step++; ?>
+        <div class="hprl-step" data-step="<?php echo $step; ?>" style="display:none;">
             <p>Preporucujemo sledece proizvode:</p>
             <div class="hprl-products">
                 <button class="hprl-select" data-type="cheap" data-product="<?php echo esc_attr( $products['cheap'] ); ?>">Jeftiniji paket</button>


### PR DESCRIPTION
## Summary
- allow setting number of questions per page via new admin option
- paginate quiz UI accordingly and show multiple steps
- save answers upon reaching product selection and later update product choice
- adjust JavaScript to work with dynamic steps

## Testing
- `php -l includes/admin-panel.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6841da778bb08322a5bc1c060aabf45f