### PR TITLE
Fix quiz result saving and CSV output

### DIFF
--- a/health-product-recommender-lite/health-product-recommender-lite.php
+++ b/health-product-recommender-lite/health-product-recommender-lite.php
@@ -16,6 +16,14 @@ define( 'HPRL_URL', plugin_dir_url( __FILE__ ) );
 
 define( 'HPRL_TABLE', $GLOBALS['wpdb']->prefix . 'health_quiz_results' );
 
+add_action( 'plugins_loaded', 'hprl_maybe_create_table' );
+function hprl_maybe_create_table() {
+    global $wpdb;
+    if ( $wpdb->get_var( $wpdb->prepare( "SHOW TABLES LIKE %s", HPRL_TABLE ) ) != HPRL_TABLE ) {
+        hprl_activate();
+    }
+}
+
 register_activation_hook( __FILE__, 'hprl_activate' );
 function hprl_activate() {
     global $wpdb;

--- a/health-product-recommender-lite/includes/admin-panel.php
+++ b/health-product-recommender-lite/includes/admin-panel.php
@@ -222,7 +222,17 @@ function hprl_results_page() {
         $out = fopen('php://output', 'w');
         fputcsv( $out, array('ID','Name','Email','Phone','Birth Year','Location','Answers','Product ID','Date') );
         foreach ( $rows as $row ) {
-            fputcsv( $out, $row );
+            fputcsv( $out, array(
+                $row['id'],
+                $row['name'],
+                $row['email'],
+                $row['phone'],
+                $row['birth_year'],
+                $row['location'],
+                implode( ',', maybe_unserialize( $row['answers'] ) ),
+                $row['product_id'],
+                $row['created_at'],
+            ) );
         }
         fclose($out);
         exit;
@@ -247,7 +257,9 @@ function hprl_results_page() {
                     <td><?php echo esc_html( $row->phone ); ?></td>
                     <td><?php echo esc_html( $row->birth_year ); ?></td>
                     <td><?php echo esc_html( $row->location ); ?></td>
-                    <td><?php echo esc_html( implode( ',', maybe_unserialize( $row->answers ) ) ); ?></td>
+                    <?php $ans = maybe_unserialize( $row->answers ); ?>
+                    <?php if ( ! is_array( $ans ) ) $ans = array( $ans ); ?>
+                    <td><?php echo esc_html( implode( ',', $ans ) ); ?></td>
                     <td><?php echo esc_html( $row->product_id ); ?></td>
                     <td><?php echo esc_html( $row->created_at ); ?></td>
                 </tr>

--- a/health-product-recommender-lite/uninstall.php
+++ b/health-product-recommender-lite/uninstall.php
@@ -6,3 +6,4 @@ $wpdb->query( "DROP TABLE IF EXISTS " . $wpdb->prefix . 'health_quiz_results' );
 
 delete_option( 'hprl_questions' );
 delete_option( 'hprl_products' );
+delete_option( 'hprl_combos' );


### PR DESCRIPTION
## Summary
- ensure quiz DB table exists on plugin load
- improve CSV export to handle serialized answers and use fixed columns
- show answers correctly on the results admin page
- clean uninstall options

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6841df1f3f4483229614a23c983b4525