### PR TITLE
Fix GitHub updates

### DIFF
--- a/health-product-recommender-lite/health-product-recommender-lite.php
+++ b/health-product-recommender-lite/health-product-recommender-lite.php
@@ -14,7 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 define( 'HPRL_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HPRL_URL', plugin_dir_url( __FILE__ ) );
 define( 'HPRL_VERSION', '1.3' );
-define( 'HPRL_UPDATE_REPO', 'beohosting/health-product-recommender-lite' );
+define( 'HPRL_UPDATE_REPO', 'beopop/eliksir' );
+define( 'HPRL_UPDATE_ASSET', 'health-product-recommender-lite.zip' );
 
 define( 'HPRL_TABLE', $GLOBALS['wpdb']->prefix . 'health_quiz_results' );
 

--- a/health-product-recommender-lite/includes/updater.php
+++ b/health-product-recommender-lite/includes/updater.php
@@ -22,6 +22,16 @@ function hprl_get_github_release() {
         return false;
     }
 
+    $data->asset_url = '';
+    if ( ! empty( $data->assets ) ) {
+        foreach ( $data->assets as $asset ) {
+            if ( isset( $asset->name ) && $asset->name === HPRL_UPDATE_ASSET && ! empty( $asset->browser_download_url ) ) {
+                $data->asset_url = $asset->browser_download_url;
+                break;
+            }
+        }
+    }
+
     return $data;
 }
 
@@ -43,7 +53,7 @@ function hprl_check_plugin_update( $transient ) {
             'plugin'      => $plugin,
             'new_version' => $new_version,
             'url'         => $release->html_url,
-            'package'     => $release->zipball_url,
+            'package'     => $release->asset_url ? $release->asset_url : $release->zipball_url,
         );
     }
 
@@ -66,7 +76,7 @@ function hprl_plugin_update_info( $res, $action, $args ) {
     $res->version       = ltrim( $release->tag_name, 'v' );
     $res->author        = '<a href="https://beohosting.com">BeoHosting</a>';
     $res->homepage      = $release->html_url;
-    $res->download_link = $release->zipball_url;
+    $res->download_link = $release->asset_url ? $release->asset_url : $release->zipball_url;
     $res->sections      = array( 'description' => $release->body );
 
     return $res;

--- a/health-product-recommender-lite/readme.txt
+++ b/health-product-recommender-lite/readme.txt
@@ -8,3 +8,8 @@ License: GPL2+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnovu zdravstvenog upitnika.
+
+== Changelog ==
+
+= 1.3.1 =
+* Improved GitHub update handler. Plugin now checks the `beopop/eliksir` repository for new releases and installs the bundled `health-product-recommender-lite.zip` asset.


### PR DESCRIPTION
## Summary
- configure plugin to look for updates in `beopop/eliksir`
- handle update asset download URL
- document update improvements in the plugin readme

## Testing
- `php -l health-product-recommender-lite/health-product-recommender-lite.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6842020557e88322b26c8da77c78a452