### PR TITLE
Fix Excel export and bump plugin version

### DIFF
--- a/health-product-recommender-lite/health-product-recommender-lite.php
+++ b/health-product-recommender-lite/health-product-recommender-lite.php
@@ -3,7 +3,7 @@
 Plugin Name: Health Product Recommender Lite
 Plugin URI: https://beohosting.com/plugins/health-product-recommender-lite
 Description: Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnovu zdravstvenog upitnika, potpuno kompatibilan sa Woodmart temom i Elementorom.
-Version: 1.3.3
+Version: 1.3.4
 Author: BeoHosting
 Author URI: https://beohosting.com
 License: GPL2+
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 define( 'HPRL_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HPRL_URL', plugin_dir_url( __FILE__ ) );
-define( 'HPRL_VERSION', '1.3.3' );
+define( 'HPRL_VERSION', '1.3.4' );
 define( 'HPRL_UPDATE_REPO', 'beopop/eliksir' );
 define( 'HPRL_UPDATE_ASSET', 'health-product-recommender-lite.zip' );
 if ( ! defined( 'HPRL_GITHUB_TOKEN' ) ) {

--- a/health-product-recommender-lite/includes/excel.php
+++ b/health-product-recommender-lite/includes/excel.php
@@ -53,6 +53,14 @@ function hprl_download_excel( array $rows, $filename = 'results.xlsx' ) {
     if ( $xlsx === false ) {
         return false;
     }
+    if ( function_exists( 'wp_ob_end_flush_all' ) ) {
+        wp_ob_end_flush_all();
+    } else {
+        while ( ob_get_level() ) {
+            ob_end_clean();
+        }
+    }
+    flush();
     header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
     header('Content-Disposition: attachment; filename="' . $filename . '"');
     header('Content-Length: ' . strlen($xlsx));

--- a/health-product-recommender-lite/readme.txt
+++ b/health-product-recommender-lite/readme.txt
@@ -3,7 +3,7 @@ Contributors: BeoHosting
 Tags: quiz, health, recommendations
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.3.3
+Stable tag: 1.3.4
 License: GPL2+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -19,3 +19,6 @@ Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnov
 
 = 1.3.3 =
 * Dodata podrška za GitHub token kako bi se plugin mogao ažurirati iz privatnog repozitorijuma.
+
+= 1.3.4 =
+* Popravljen Excel export. Fajl se sada ispravno generiše bez dodatnog izlaza.


### PR DESCRIPTION
## Summary
- bump plugin version to 1.3.4
- flush output before sending Excel export
- document update in readme

## Testing
- `php -l health-product-recommender-lite.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684208418e8c83229901c80b564ad08f