### PR TITLE
Remove token from GitHub update URLs

### DIFF
--- a/health-product-recommender-lite/includes/updater.php
+++ b/health-product-recommender-lite/includes/updater.php
@@ -27,10 +27,8 @@ function hprl_github_auth_header( $args, $url ) {
 }
 
 function hprl_add_github_token_to_url( $url ) {
-    $token = hprl_get_github_token();
-    if ( $token ) {
-        $url = add_query_arg( 'access_token', $token, $url );
-    }
+    // Token no longer appended to the URL. Authentication is handled via
+    // hprl_github_auth_header which sets the Authorization header.
     return $url;
 }
 
@@ -93,7 +91,7 @@ function hprl_check_plugin_update( $transient ) {
             'plugin'      => $plugin,
             'new_version' => $new_version,
             'url'         => $release->html_url,
-            'package'     => hprl_add_github_token_to_url( $package ),
+            'package'     => $package,
         );
     }
 
@@ -117,7 +115,7 @@ function hprl_plugin_update_info( $res, $action, $args ) {
     $res->author        = '<a href="https://beohosting.com">BeoHosting</a>';
     $res->homepage      = $release->html_url;
     $download = $release->asset_url ? $release->asset_url : $release->zipball_url;
-    $res->download_link = hprl_add_github_token_to_url( $download );
+    $res->download_link = $download;
     $res->sections      = array( 'description' => $release->body );
 
     return $res;


### PR DESCRIPTION
## Summary
- stop adding `access_token` to GitHub URLs
- use header-based authentication for plugin updates

## Testing
- `curl -I https://github.com` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68420a73d2548322b102ca8b8aa3b4c3