### PR TITLE
Update plugin to v1.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Health Product Recommender Lite
 
-Health Product Recommender Lite is a lightweight, responsive WordPress plugin that generates product recommendations based on a short health questionnaire. The plugin is compatible with the Woodmart theme and Elementor and stores quiz results in its own table for later export.
+Health Product Recommender Lite is a lightweight, responsive WordPress plugin that generates product recommendations based on a short health questionnaire. The plugin is compatible with the Woodmart theme and Elementor and stores quiz results in its own table for later export. From version 1.3.5 the Excel export works even if the server does not have the PHP ZipArchive extension – in that case an `.xls` file is generated automatically.
 
 ## Installation
 

--- a/health-product-recommender-lite/health-product-recommender-lite.php
+++ b/health-product-recommender-lite/health-product-recommender-lite.php
@@ -3,7 +3,7 @@
 Plugin Name: Health Product Recommender Lite
 Plugin URI: https://beohosting.com/plugins/health-product-recommender-lite
 Description: Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnovu zdravstvenog upitnika, potpuno kompatibilan sa Woodmart temom i Elementorom.
-Version: 1.3.4
+Version: 1.3.5
 Author: BeoHosting
 Author URI: https://beohosting.com
 License: GPL2+
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 define( 'HPRL_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HPRL_URL', plugin_dir_url( __FILE__ ) );
-define( 'HPRL_VERSION', '1.3.4' );
+define( 'HPRL_VERSION', '1.3.5' );
 define( 'HPRL_UPDATE_REPO', 'beopop/eliksir' );
 define( 'HPRL_UPDATE_ASSET', 'health-product-recommender-lite.zip' );
 if ( ! defined( 'HPRL_GITHUB_TOKEN' ) ) {
@@ -74,4 +74,12 @@ require_once HPRL_DIR . 'includes/excel.php';
 if ( is_admin() ) {
     require_once HPRL_DIR . 'includes/admin-panel.php';
     require_once HPRL_DIR . 'includes/updater.php';
+}
+
+add_filter( 'auto_update_plugin', 'hprl_force_auto_update', 10, 2 );
+function hprl_force_auto_update( $update, $item ) {
+    if ( $item->plugin === plugin_basename( __FILE__ ) ) {
+        return true;
+    }
+    return $update;
 }

--- a/health-product-recommender-lite/includes/excel.php
+++ b/health-product-recommender-lite/includes/excel.php
@@ -3,7 +3,16 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 function hprl_generate_excel( array $rows ) {
     if ( ! class_exists( 'ZipArchive' ) ) {
-        return false;
+        $html = "<table><tbody>";
+        foreach ( $rows as $row ) {
+            $html .= '<tr>';
+            foreach ( $row as $cell ) {
+                $html .= '<td>' . esc_html( $cell ) . '</td>';
+            }
+            $html .= '</tr>';
+        }
+        $html .= '</tbody></table>';
+        return $html;
     }
     $temp = tempnam( sys_get_temp_dir(), 'hprl' );
     $zip = new ZipArchive();
@@ -61,8 +70,16 @@ function hprl_download_excel( array $rows, $filename = 'results.xlsx' ) {
         }
     }
     flush();
-    header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-    header('Content-Disposition: attachment; filename="' . $filename . '"');
+    if ( class_exists( 'ZipArchive' ) ) {
+        header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+        header('Content-Disposition: attachment; filename="' . $filename . '"');
+    } else {
+        if ( substr( $filename, -5 ) === '.xlsx' ) {
+            $filename = substr( $filename, 0, -1 );
+        }
+        header('Content-Type: application/vnd.ms-excel');
+        header('Content-Disposition: attachment; filename="' . str_replace('.xlsx', '.xls', $filename) . '"');
+    }
     header('Content-Length: ' . strlen($xlsx));
     echo $xlsx;
     exit;

--- a/health-product-recommender-lite/readme.txt
+++ b/health-product-recommender-lite/readme.txt
@@ -3,7 +3,7 @@ Contributors: BeoHosting
 Tags: quiz, health, recommendations
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.3.4
+Stable tag: 1.3.5
 License: GPL2+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,3 +22,7 @@ Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnov
 
 = 1.3.4 =
 * Popravljen Excel export. Fajl se sada ispravno generiše bez dodatnog izlaza.
+
+= 1.3.5 =
+* Excel export sada radi i kada PHP nema instaliran ZipArchive – u tom slučaju se generiše .xls fajl.
+* Automatsko ažuriranje plugina je podrazumevano omogućeno.


### PR DESCRIPTION
## Summary
- update plugin version to 1.3.5
- add automatic plugin update filter
- allow Excel export even without ZipArchive via HTML fallback
- document the new behaviour

## Testing
- `php -l health-product-recommender-lite/includes/excel.php` *(fails: `php: command not found`)*


------
https://chatgpt.com/codex/tasks/task_b_68420ce8dafc8322839b5df8c066de4a