### PR TITLE
Add update log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ define( 'HPRL_GITHUB_TOKEN', 'your_token_here' );
 If the update process fails:
 
 - Verify that the token is correct and has permission to access the repository.
-- Enable **Debug log** in the plugin settings to display any update errors.
+- Enable **Debug log** in the plugin settings. When enabled the plugin writes
+  update errors to `wp-content/uploads/hprl-update.log` and shows an admin
+  notice if possible.
 - Manual installation of a release ZIP is always possible if automatic updates do not work.
 
 ## Version history

--- a/health-product-recommender-lite/includes/updater.php
+++ b/health-product-recommender-lite/includes/updater.php
@@ -45,6 +45,13 @@ function hprl_show_update_error_notice() {
 function hprl_log_update_error( $msg ) {
     if ( get_option( 'hprl_debug_log', 0 ) ) {
         error_log( 'HPRL update error: ' . $msg );
+        // Also write update errors to a dedicated log file inside wp-content/uploads
+        $upload_dir = wp_upload_dir();
+        if ( ! empty( $upload_dir['basedir'] ) ) {
+            $log_file = trailingslashit( $upload_dir['basedir'] ) . 'hprl-update.log';
+            $entry = '[' . date( 'Y-m-d H:i:s' ) . '] ' . $msg . PHP_EOL;
+            @file_put_contents( $log_file, $entry, FILE_APPEND );
+        }
     }
     if ( current_user_can( 'manage_options' ) ) {
         $GLOBALS['hprl_update_error_msg'] = 'Health Product Recommender Lite update error: ' . $msg;


### PR DESCRIPTION
## Summary
- log update errors to a dedicated file inside `wp-content/uploads`
- document the new log location in the README

## Testing
- `php -l health-product-recommender-lite/includes/updater.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6842117ae2f483229d2bf2bc4c6fb712