### PR TITLE
Handle GitHub 404 response

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ define( 'HPRL_GITHUB_TOKEN', 'your_token_here' );
 If the update process fails:
 
 - Verify that the token is correct and has permission to access the repository.
+- If the log shows `GitHub API returned 404`, the release was not found or your
+  token cannot access the repository.
 - Enable **Debug log** in the plugin settings. When enabled the plugin writes
   update errors to `wp-content/uploads/hprl-update.log` and shows an admin
   notice if possible.

--- a/health-product-recommender-lite/includes/updater.php
+++ b/health-product-recommender-lite/includes/updater.php
@@ -83,6 +83,12 @@ function hprl_get_github_release() {
     }
 
     $code = wp_remote_retrieve_response_code( $response );
+    if ( $code && 404 == intval( $code ) ) {
+        hprl_log_update_error(
+            'GitHub API returned 404 (release not found or repository inaccessible).'
+        );
+        return false;
+    }
     if ( $code && 200 !== intval( $code ) ) {
         hprl_log_update_error( 'GitHub API returned HTTP ' . $code );
         return false;


### PR DESCRIPTION
## Summary
- handle `404` status code separately in `hprl_get_github_release`
- document troubleshooting step for GitHub 404 errors

## Testing
- `php -l health-product-recommender-lite/includes/updater.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684214b70b788322a0b802ce058c4e6e