### PR TITLE
Add note editor for result combos

### DIFF
--- a/health-product-recommender-lite/assets/css/style.css
+++ b/health-product-recommender-lite/assets/css/style.css
@@ -8,3 +8,4 @@
 #hprl-quiz .hprl-select img{max-width:120px;display:block;margin:0 auto 5px;}
 #hprl-quiz .hprl-price{display:block;margin-top:5px;}
 #hprl-debug-log{background:#f5f5f5;padding:10px;border:1px solid #ccc;white-space:pre-wrap;}
+.hprl-note{background:#e6f4ea;border-left:5px solid #3aa15c;padding:10px;margin-top:15px;border-radius:4px;color:#2f5d3c;}

--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded',function(){
   const debugContainer=document.getElementById('hprl-debug-container');
   const debugToggle=document.getElementById('hprl-debug-toggle');
   const debugLog=document.getElementById('hprl-debug-log');
+  const noteBox=document.getElementById('hprl-note');
   if(debugToggle){
     debugToggle.addEventListener('change',()=>{debugLog.style.display=debugToggle.checked?'block':'none';});
   }
@@ -15,6 +16,15 @@ document.addEventListener('DOMContentLoaded',function(){
     if(!debugMode||!debugContainer) return;
     debugContainer.style.display='block';
     debugLog.textContent=log;
+  }
+  function updateNote(text){
+    if(!noteBox) return;
+    if(text){
+      noteBox.innerHTML=text;
+      noteBox.style.display='block';
+    }else{
+      noteBox.style.display='none';
+    }
   }
   function updateProductInfo(type,id){
     const btn=quiz.querySelector('.hprl-select[data-type="'+type+'"]');
@@ -105,12 +115,15 @@ document.addEventListener('DOMContentLoaded',function(){
         let cheap=hprlData.cheap;
         let premium=hprlData.premium;
         const key=indexes.join('|');
+        let note='';
         if(hprlData.combos&&hprlData.combos[key]){
           cheap=hprlData.combos[key].cheap;
           premium=hprlData.combos[key].premium;
+          note=hprlData.combos[key].note||'';
         }
         updateProductInfo('cheap',cheap);
         updateProductInfo('premium',premium);
+        updateNote(note);
         const data=new FormData();
         data.append('action','hprl_save_answers');
         data.append('nonce',hprlData.nonce);
@@ -159,5 +172,6 @@ document.addEventListener('DOMContentLoaded',function(){
   });
   updateProductInfo('cheap',hprlData.cheap);
   updateProductInfo('premium',hprlData.premium);
+  updateNote('');
   showStep(0);
 });

--- a/health-product-recommender-lite/health-product-recommender-lite.php
+++ b/health-product-recommender-lite/health-product-recommender-lite.php
@@ -3,7 +3,7 @@
 Plugin Name: Health Product Recommender Lite
 Plugin URI: https://beohosting.com/plugins/health-product-recommender-lite
 Description: Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnovu zdravstvenog upitnika, potpuno kompatibilan sa Woodmart temom i Elementorom.
-Version: 1.3.7
+Version: 1.3.8
 Author: BeoHosting
 Author URI: https://beohosting.com
 License: GPL2+
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 define( 'HPRL_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HPRL_URL', plugin_dir_url( __FILE__ ) );
-define( 'HPRL_VERSION', '1.3.7' );
+define( 'HPRL_VERSION', '1.3.8' );
 define( 'HPRL_UPDATE_REPO', 'beopop/eliksir' );
 define( 'HPRL_UPDATE_ASSET', 'health-product-recommender-lite.zip' );
 if ( ! defined( 'HPRL_GITHUB_TOKEN' ) ) {

--- a/health-product-recommender-lite/includes/admin-panel.php
+++ b/health-product-recommender-lite/includes/admin-panel.php
@@ -97,10 +97,12 @@ function hprl_questions_page() {
                 if ( $empty ) {
                     continue;
                 }
+                $note = isset( $_POST['combo_note'][ $i ] ) ? wp_kses_post( $_POST['combo_note'][ $i ] ) : '';
                 $combos[] = array(
                     'answers' => $answers,
                     'cheap'   => intval( $_POST['combo_cheap'][ $i ] ),
                     'premium' => intval( $_POST['combo_premium'][ $i ] ),
+                    'note'    => $note,
                 );
             }
         }
@@ -128,6 +130,9 @@ function hprl_questions_page() {
                 $new[] = ( $p === '' ) ? array() : array( intval( $p ) );
             }
             $c['answers'] = $new;
+        }
+        if ( ! isset( $c['note'] ) ) {
+            $c['note'] = '';
         }
     }
     unset( $c );
@@ -214,9 +219,10 @@ function hprl_questions_page() {
                     <th>Kombinacija odgovora</th>
                     <th>Jeftiniji proizvod</th>
                     <th>Skuplji proizvod</th>
+                    <th>Objašnjenje</th>
                 </tr>
                 <?php for ( $i = 0; $i < $max_c; $i++ ) :
-                    $c = isset( $combos[ $i ] ) ? $combos[ $i ] : array( 'answers' => array(), 'cheap' => '', 'premium' => '' );
+                    $c = isset( $combos[ $i ] ) ? $combos[ $i ] : array( 'answers' => array(), 'cheap' => '', 'premium' => '', 'note' => '' );
                 ?>
                 <tr>
                     <td>
@@ -246,6 +252,18 @@ function hprl_questions_page() {
                                 <option value="<?php echo esc_attr( $pid ); ?>" <?php selected( intval( $c['premium'] ) === $pid ); ?>><?php echo esc_html( $title ); ?></option>
                             <?php endforeach; ?>
                         </select>
+                    </td>
+                    <td>
+                        <?php
+                        $note = isset( $c['note'] ) ? $c['note'] : '';
+                        $eid  = 'combo_note_' . $i;
+                        wp_editor( $note, $eid, array(
+                            'textarea_name' => "combo_note[$i]",
+                            'teeny'         => true,
+                            'media_buttons' => false,
+                            'textarea_rows' => 3,
+                        ) );
+                        ?>
                     </td>
                 </tr>
                 <?php endfor; ?>

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -22,10 +22,18 @@ function hprl_quiz_shortcode() {
         if ( is_array( $c['answers'] ) ) {
             $keys = hprl_cartesian_product( array_map( function( $v ) { return (array) $v; }, $c['answers'] ) );
             foreach ( $keys as $k ) {
-                $combos_out[ implode( '|', $k ) ] = array( 'cheap' => $c['cheap'], 'premium' => $c['premium'] );
+                $combos_out[ implode( '|', $k ) ] = array(
+                    'cheap'   => $c['cheap'],
+                    'premium' => $c['premium'],
+                    'note'    => isset( $c['note'] ) ? $c['note'] : ''
+                );
             }
         } else {
-            $combos_out[ $c['answers'] ] = array( 'cheap' => $c['cheap'], 'premium' => $c['premium'] );
+            $combos_out[ $c['answers'] ] = array(
+                'cheap'   => $c['cheap'],
+                'premium' => $c['premium'],
+                'note'    => isset( $c['note'] ) ? $c['note'] : ''
+            );
         }
     }
 
@@ -119,6 +127,7 @@ function hprl_quiz_shortcode() {
                     <span class="hprl-price"><?php echo wp_kses_post( $premium_data['price'] ); ?></span>
                 </button>
             </div>
+            <div id="hprl-note" class="hprl-note" style="display:none;"></div>
         </div>
         <div id="hprl-debug-container" style="display:none;">
             <label><input type="checkbox" id="hprl-debug-toggle"> Prikaži log greške</label>

--- a/health-product-recommender-lite/includes/utils.php
+++ b/health-product-recommender-lite/includes/utils.php
@@ -31,7 +31,7 @@ function hprl_generate_all_combos($questions) {
         foreach ($p as $idx) {
             $answers[] = array($idx);
         }
-        $combos[] = array('answers' => $answers, 'cheap' => '', 'premium' => '');
+        $combos[] = array('answers' => $answers, 'cheap' => '', 'premium' => '', 'note' => '');
     }
     return $combos;
 }

--- a/health-product-recommender-lite/readme.txt
+++ b/health-product-recommender-lite/readme.txt
@@ -3,7 +3,7 @@ Contributors: BeoHosting
 Tags: quiz, health, recommendations
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.3.7
+Stable tag: 1.3.8
 License: GPL2+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -32,3 +32,6 @@ Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnov
 
 = 1.3.7 =
 * Na poslednjem koraku prikazuju se slika proizvoda i cena umesto tekstualnog dugmeta.
+
+= 1.3.8 =
+* Svakoj kombinaciji odgovora može se dodeliti objašnjenje preko klasičnog editora koje se prikazuje ispod predloženih proizvoda.


### PR DESCRIPTION
## Summary
- enable adding notes to answer combinations
- show notes on the results step
- style notes as green info bubbles
- bump version to 1.3.8

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6842192139308322ae68719bf238fb4c