### PR TITLE
Improve quiz UX

### DIFF
--- a/health-product-recommender-lite/assets/css/style.css
+++ b/health-product-recommender-lite/assets/css/style.css
@@ -9,3 +9,11 @@
 #hprl-quiz .hprl-price{display:block;margin-top:5px;}
 #hprl-debug-log{background:#f5f5f5;padding:10px;border:1px solid #ccc;white-space:pre-wrap;}
 .hprl-note{background:#e6f4ea;border-left:5px solid #3aa15c;padding:10px;margin-top:15px;border-radius:4px;color:#2f5d3c;}
+#hprl-quiz .hprl-next{background:#0073aa;color:#fff;padding:12px 24px;font-size:16px;border:none;border-radius:4px;}
+#hprl-quiz .hprl-next:hover{background:#006799;}
+.hprl-question-group{margin-bottom:15px;}
+.hprl-question-group p{margin-bottom:8px;font-weight:bold;}
+.hprl-question-group label.hprl-answer{display:inline-block;margin-right:10px;margin-bottom:10px;}
+.hprl-question-group label.hprl-answer input{display:none;}
+.hprl-question-group label.hprl-answer span{display:block;padding:8px 15px;border:1px solid #ccc;border-radius:4px;background:#f2f2f2;cursor:pointer;transition:background .3s;}
+.hprl-question-group label.hprl-answer input:checked+span{background:#0073aa;color:#fff;border-color:#0073aa;}

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -96,9 +96,9 @@ function hprl_quiz_shortcode() {
                 <div class="hprl-question-group" data-question="<?php echo $q_index; ?>">
                     <p><?php echo esc_html( $q['text'] ); ?></p>
                     <?php foreach ( $q['answers'] as $a_idx => $ans ) : ?>
-                        <label>
+                        <label class="hprl-answer">
                             <input type="radio" name="q<?php echo $q_index; ?>" class="hprl-question" data-index="<?php echo $a_idx; ?>" value="<?php echo esc_attr( $ans ); ?>" required>
-                            <?php echo esc_html( $ans ); ?>
+                            <span><?php echo esc_html( $ans ); ?></span>
                         </label>
                     <?php endforeach; ?>
                     <span class="hprl-error"></span>


### PR DESCRIPTION
## Summary
- make answers appear as buttons rather than radio inputs
- style Next button with theme color and enlarge it
- add basic spacing and highlight for selected answers

## Testing
- `php -l health-product-recommender-lite/includes/shortcodes.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68429020461083229ed00a75fe0860e8