### PR TITLE
Implement separate name fields and styling update

### DIFF
--- a/health-product-recommender-lite/assets/css/style.css
+++ b/health-product-recommender-lite/assets/css/style.css
@@ -9,11 +9,11 @@
 #hprl-quiz .hprl-price{display:block;margin-top:5px;}
 #hprl-debug-log{background:#f5f5f5;padding:10px;border:1px solid #ccc;white-space:pre-wrap;}
 .hprl-note{background:#e6f4ea;border-left:5px solid #3aa15c;padding:10px;margin-top:15px;border-radius:4px;color:#2f5d3c;}
-#hprl-quiz .hprl-next{background:#0073aa;color:#fff;padding:12px 24px;font-size:16px;border:none;border-radius:4px;}
-#hprl-quiz .hprl-next:hover{background:#006799;}
+#hprl-quiz .hprl-next{background:rgba(0,88,64,1);color:#fff;padding:12px 24px;font-size:16px;border:none;border-radius:4px;}
+#hprl-quiz .hprl-next:hover{background:rgba(0,88,64,0.8);}
 .hprl-question-group{margin-bottom:15px;}
 .hprl-question-group p{margin-bottom:8px;font-weight:bold;}
 .hprl-question-group label.hprl-answer{display:inline-block;margin-right:10px;margin-bottom:10px;}
 .hprl-question-group label.hprl-answer input{display:none;}
 .hprl-question-group label.hprl-answer span{display:block;padding:8px 15px;border:1px solid #ccc;border-radius:4px;background:#f2f2f2;cursor:pointer;transition:background .3s;}
-.hprl-question-group label.hprl-answer input:checked+span{background:#0073aa;color:#fff;border-color:#0073aa;}
+.hprl-question-group label.hprl-answer input:checked+span{background:rgba(0,88,64,1);color:#fff;border-color:rgba(0,88,64,1);}

--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -82,16 +82,19 @@ document.addEventListener('DOMContentLoaded',function(){
       const step=parseInt(stepElem.dataset.step);
       clearErrors(stepElem);
       if(step===1){
-        const nameInput=document.getElementById('hprl-name');
+        const firstNameInput=document.getElementById('hprl-first-name');
+        const lastNameInput=document.getElementById('hprl-last-name');
         const emailInput=document.getElementById('hprl-email');
         const phoneInput=document.getElementById('hprl-phone');
         const yearInput=document.getElementById('hprl-year');
-        const name=nameInput.value.trim();
+        const firstName=firstNameInput.value.trim();
+        const lastName=lastNameInput.value.trim();
         const email=emailInput.value.trim();
         const phone=phoneInput.value.trim();
         const year=yearInput.value.trim();
         let valid=true;
-        if(!name){showError(nameInput,'Unesite ime i prezime.');valid=false;}
+        if(!firstName){showError(firstNameInput,'Unesite ime.');valid=false;}
+        if(!lastName){showError(lastNameInput,'Unesite prezime.');valid=false;}
         if(!email){showError(emailInput,'Unesite email.');valid=false;}
         else if(!/^([^\s@]+)@([^\s@]+)\.[^\s@]+$/.test(email)){showError(emailInput,'Neispravan email.');valid=false;}
         if(!phone){showError(phoneInput,'Unesite telefon.');valid=false;}
@@ -127,7 +130,8 @@ document.addEventListener('DOMContentLoaded',function(){
         const data=new FormData();
         data.append('action','hprl_save_answers');
         data.append('nonce',hprlData.nonce);
-        data.append('name',document.getElementById('hprl-name').value);
+        data.append('first_name',document.getElementById('hprl-first-name').value);
+        data.append('last_name',document.getElementById('hprl-last-name').value);
         data.append('email',document.getElementById('hprl-email').value);
         data.append('phone',document.getElementById('hprl-phone').value);
         data.append('birth_year',document.getElementById('hprl-year').value);

--- a/health-product-recommender-lite/health-product-recommender-lite.php
+++ b/health-product-recommender-lite/health-product-recommender-lite.php
@@ -3,7 +3,7 @@
 Plugin Name: Health Product Recommender Lite
 Plugin URI: https://beohosting.com/plugins/health-product-recommender-lite
 Description: Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnovu zdravstvenog upitnika, potpuno kompatibilan sa Woodmart temom i Elementorom.
-Version: 1.3.9
+Version: 1.4.0
 Author: BeoHosting
 Author URI: https://beohosting.com
 License: GPL2+
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 define( 'HPRL_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HPRL_URL', plugin_dir_url( __FILE__ ) );
-define( 'HPRL_VERSION', '1.3.9' );
+define( 'HPRL_VERSION', '1.4.0' );
 define( 'HPRL_UPDATE_REPO', 'beopop/eliksir' );
 define( 'HPRL_UPDATE_ASSET', 'health-product-recommender-lite.zip' );
 if ( ! defined( 'HPRL_GITHUB_TOKEN' ) ) {
@@ -34,6 +34,14 @@ function hprl_maybe_create_table() {
         if ( empty( $column ) ) {
             $wpdb->query( "ALTER TABLE `" . HPRL_TABLE . "` ADD `product_id` bigint(20) NOT NULL DEFAULT 0 AFTER `answers`" );
         }
+        $column = $wpdb->get_results( "SHOW COLUMNS FROM `" . HPRL_TABLE . "` LIKE 'first_name'" );
+        if ( empty( $column ) ) {
+            $wpdb->query( "ALTER TABLE `" . HPRL_TABLE . "` ADD `first_name` varchar(200) NOT NULL AFTER `id`" );
+        }
+        $column = $wpdb->get_results( "SHOW COLUMNS FROM `" . HPRL_TABLE . "` LIKE 'last_name'" );
+        if ( empty( $column ) ) {
+            $wpdb->query( "ALTER TABLE `" . HPRL_TABLE . "` ADD `last_name` varchar(200) NOT NULL AFTER `first_name`" );
+        }
     }
 }
 
@@ -43,7 +51,8 @@ function hprl_activate() {
     $charset_collate = $wpdb->get_charset_collate();
     $sql = "CREATE TABLE IF NOT EXISTS " . HPRL_TABLE . " (
         id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-        name varchar(200) NOT NULL,
+        first_name varchar(200) NOT NULL,
+        last_name varchar(200) NOT NULL,
         email varchar(200) NOT NULL,
         phone varchar(100) NOT NULL,
         birth_year int(4) NOT NULL,

--- a/health-product-recommender-lite/includes/admin-panel.php
+++ b/health-product-recommender-lite/includes/admin-panel.php
@@ -22,7 +22,7 @@ function hprl_handle_export() {
 
     global $wpdb;
     $rows = $wpdb->get_results( "SELECT * FROM " . HPRL_TABLE . " ORDER BY created_at DESC", ARRAY_A );
-    $header = array( 'ID','Name','Email','Phone','Birth Year','Location','Answers','Product ID','Date' );
+    $header = array( 'ID','First Name','Last Name','Email','Phone','Birth Year','Location','Answers','Product ID','Date' );
 
     header( 'Content-Type: text/csv' );
     header( 'Content-Disposition: attachment; filename="hprl-results.csv"' );
@@ -31,7 +31,8 @@ function hprl_handle_export() {
     foreach ( $rows as $row ) {
         fputcsv( $out, array(
             $row['id'],
-            $row['name'],
+            isset( $row['first_name'] ) ? $row['first_name'] : '',
+            isset( $row['last_name'] ) ? $row['last_name'] : '',
             $row['email'],
             $row['phone'],
             $row['birth_year'],
@@ -308,14 +309,15 @@ function hprl_results_page() {
         <table class="widefat">
             <thead>
             <tr>
-                <th>ID</th><th>Ime</th><th>Email</th><th>Telefon</th><th>Godina</th><th>Mesto</th><th>Odgovori</th><th>Proizvod</th><th>Datum</th><th>Akcija</th>
+                <th>ID</th><th>Ime</th><th>Prezime</th><th>Email</th><th>Telefon</th><th>Godina</th><th>Mesto</th><th>Odgovori</th><th>Proizvod</th><th>Datum</th><th>Akcija</th>
             </tr>
             </thead>
             <tbody>
             <?php foreach ( $results as $row ) : ?>
                 <tr>
                     <td><?php echo esc_html( $row->id ); ?></td>
-                    <td><?php echo esc_html( $row->name ); ?></td>
+                    <td><?php echo esc_html( $row->first_name ); ?></td>
+                    <td><?php echo esc_html( $row->last_name ); ?></td>
                     <td><?php echo esc_html( $row->email ); ?></td>
                     <td><?php echo esc_html( $row->phone ); ?></td>
                     <td><?php echo esc_html( $row->birth_year ); ?></td>

--- a/health-product-recommender-lite/includes/data-handler.php
+++ b/health-product-recommender-lite/includes/data-handler.php
@@ -7,7 +7,8 @@ function hprl_save_quiz() {
     check_ajax_referer( 'hprl_nonce', 'nonce' );
     global $wpdb;
     $debug = intval( get_option( 'hprl_debug_log', 0 ) );
-    $name = sanitize_text_field( $_POST['name'] );
+    $first_name = sanitize_text_field( $_POST['first_name'] );
+    $last_name  = sanitize_text_field( $_POST['last_name'] );
     $email = sanitize_email( $_POST['email'] );
     if ( ! is_email( $email ) ) {
         wp_send_json_error( array( 'message' => 'Neispravan email.' ) );
@@ -22,7 +23,8 @@ function hprl_save_quiz() {
     $product_id = intval( $_POST['product'] );
 
     $inserted = $wpdb->insert( HPRL_TABLE, [
-        'name'       => $name,
+        'first_name' => $first_name,
+        'last_name'  => $last_name,
         'email'      => $email,
         'phone'      => $phone,
         'birth_year' => $birth_year,
@@ -50,7 +52,8 @@ function hprl_save_answers() {
     check_ajax_referer( 'hprl_nonce', 'nonce' );
     global $wpdb;
     $debug = intval( get_option( 'hprl_debug_log', 0 ) );
-    $name = sanitize_text_field( $_POST['name'] );
+    $first_name = sanitize_text_field( $_POST['first_name'] );
+    $last_name  = sanitize_text_field( $_POST['last_name'] );
     $email = sanitize_email( $_POST['email'] );
     if ( ! is_email( $email ) ) {
         wp_send_json_error( array( 'message' => 'Neispravan email.' ) );
@@ -64,7 +67,8 @@ function hprl_save_answers() {
     $answers = isset( $_POST['answers'] ) ? array_map( 'sanitize_text_field', $_POST['answers'] ) : array();
 
     $inserted = $wpdb->insert( HPRL_TABLE, [
-        'name'       => $name,
+        'first_name' => $first_name,
+        'last_name'  => $last_name,
         'email'      => $email,
         'phone'      => $phone,
         'birth_year' => $birth_year,

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -69,9 +69,13 @@ function hprl_quiz_shortcode() {
     <div id="hprl-quiz">
         <?php $step = 1; ?>
         <div class="hprl-step" data-step="<?php echo $step; ?>">
-            <label>Ime i prezime*<br>
-                <input type="text" id="hprl-name" required>
-                <span class="hprl-error" id="hprl-name-error"></span>
+            <label>Ime*<br>
+                <input type="text" id="hprl-first-name" required>
+                <span class="hprl-error" id="hprl-first-name-error"></span>
+            </label>
+            <label>Prezime*<br>
+                <input type="text" id="hprl-last-name" required>
+                <span class="hprl-error" id="hprl-last-name-error"></span>
             </label>
             <label>Email*<br>
                 <input type="email" id="hprl-email" required>

--- a/health-product-recommender-lite/readme.txt
+++ b/health-product-recommender-lite/readme.txt
@@ -3,7 +3,7 @@ Contributors: BeoHosting
 Tags: quiz, health, recommendations
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.3.9
+Stable tag: 1.4.0
 License: GPL2+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -38,3 +38,7 @@ Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnov
 
 = 1.3.9 =
 * Token za GitHub se sada dodaje direktno na URL paketa kako bi se izbegle greške "Download failed: Not Found" pri ažuriranju.
+
+= 1.4.0 =
+* Form now separates first and last name fields.
+* Buttons styled with dark green color.


### PR DESCRIPTION
## Summary
- update button styling to use dark green
- split name input into first and last name fields
- store first and last name separately in database
- show first and last name in admin export and results
- bump plugin version to 1.4.0

## Testing
- `node --check health-product-recommender-lite/assets/js/script.js`


------
https://chatgpt.com/codex/tasks/task_b_68429222e3b88322bed3b58eae1bf178