### PR TITLE
Add WooCommerce checkout autofill

### DIFF
--- a/health-product-recommender-lite/assets/js/checkout-fill.js
+++ b/health-product-recommender-lite/assets/js/checkout-fill.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded',function(){
+  try{
+    const stored=localStorage.getItem('hprl_checkout');
+    if(!stored) return;
+    const data=JSON.parse(stored);
+    const map={
+      first_name:'#billing_first_name',
+      last_name:'#billing_last_name',
+      email:'#billing_email',
+      phone:'#billing_phone',
+      city:'#billing_city'
+    };
+    Object.keys(map).forEach(key=>{
+      if(data[key]){
+        const el=document.querySelector(map[key]);
+        if(el&& !el.value){
+          el.value=data[key];
+        }
+      }
+    });
+    localStorage.removeItem('hprl_checkout');
+  }catch(e){
+    console.error('HPRL checkout fill error',e);
+  }
+});

--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -154,6 +154,16 @@ document.addEventListener('DOMContentLoaded',function(){
   });
   quiz.querySelectorAll('.hprl-select').forEach(btn=>{
     btn.addEventListener('click',async function(){
+      try{
+        const checkoutData={
+          first_name:document.getElementById('hprl-first-name').value.trim(),
+          last_name:document.getElementById('hprl-last-name').value.trim(),
+          email:document.getElementById('hprl-email').value.trim(),
+          phone:document.getElementById('hprl-phone').value.trim(),
+          city:document.getElementById('hprl-location').value.trim()
+        };
+        localStorage.setItem('hprl_checkout',JSON.stringify(checkoutData));
+      }catch(e){}
       if(saveAnswersPromise) await saveAnswersPromise;
       const data=new FormData();
       data.append('action','hprl_set_product');

--- a/health-product-recommender-lite/health-product-recommender-lite.php
+++ b/health-product-recommender-lite/health-product-recommender-lite.php
@@ -79,6 +79,12 @@ function hprl_uninstall() {
 require_once HPRL_DIR . 'includes/utils.php';
 require_once HPRL_DIR . 'includes/data-handler.php';
 require_once HPRL_DIR . 'includes/shortcodes.php';
+add_action( 'wp_enqueue_scripts', 'hprl_enqueue_checkout_fill_script' );
+function hprl_enqueue_checkout_fill_script() {
+    if ( function_exists( 'is_checkout' ) && is_checkout() && ! is_wc_endpoint_url( 'order-received' ) ) {
+        wp_enqueue_script( 'hprl-checkout-fill', HPRL_URL . 'assets/js/checkout-fill.js', array( 'jquery' ), HPRL_VERSION, true );
+    }
+}
 if ( is_admin() ) {
     require_once HPRL_DIR . 'includes/admin-panel.php';
     require_once HPRL_DIR . 'includes/updater.php';


### PR DESCRIPTION
## Summary
- autofill WooCommerce billing fields with quiz info
- save quiz data before redirecting to checkout

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6842962fe65c8322aae24f291dce158b