### PR TITLE
Enhance product result display

### DIFF
--- a/health-product-recommender-lite/assets/css/style.css
+++ b/health-product-recommender-lite/assets/css/style.css
@@ -6,7 +6,9 @@
 @media(max-width:600px){.hprl-products{flex-direction:column;}}
 .hprl-error{color:red;font-size:.9em;display:none;}
 #hprl-quiz .hprl-select img{max-width:120px;display:block;margin:0 auto 5px;}
+#hprl-quiz .hprl-name{display:block;font-weight:bold;margin-top:5px;}
 #hprl-quiz .hprl-price{display:block;margin-top:5px;}
+#hprl-quiz .hprl-label{display:block;font-size:.9em;color:#555;}
 #hprl-debug-log{background:#f5f5f5;padding:10px;border:1px solid #ccc;white-space:pre-wrap;}
 .hprl-note{background:#e6f4ea;border-left:5px solid #3aa15c;padding:10px;margin-top:15px;border-radius:4px;color:#2f5d3c;}
 #hprl-quiz .hprl-next{background:rgba(0,88,64,1);color:#fff;padding:12px 24px;font-size:16px;border:none;border-radius:4px;}

--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -36,6 +36,8 @@ document.addEventListener('DOMContentLoaded',function(){
       if(img&&info.img) img.src=info.img;
       const price=btn.querySelector('.hprl-price');
       if(price) price.innerHTML=info.price;
+      const nameEl=btn.querySelector('.hprl-name');
+      if(nameEl&&info.name) nameEl.textContent=info.name;
     }
   }
   function showStep(index){

--- a/health-product-recommender-lite/health-product-recommender-lite.php
+++ b/health-product-recommender-lite/health-product-recommender-lite.php
@@ -3,7 +3,7 @@
 Plugin Name: Health Product Recommender Lite
 Plugin URI: https://beohosting.com/plugins/health-product-recommender-lite
 Description: Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnovu zdravstvenog upitnika, potpuno kompatibilan sa Woodmart temom i Elementorom.
-Version: 1.4.0
+Version: 1.4.1
 Author: BeoHosting
 Author URI: https://beohosting.com
 License: GPL2+
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 define( 'HPRL_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HPRL_URL', plugin_dir_url( __FILE__ ) );
-define( 'HPRL_VERSION', '1.4.0' );
+define( 'HPRL_VERSION', '1.4.1' );
 define( 'HPRL_UPDATE_REPO', 'beopop/eliksir' );
 define( 'HPRL_UPDATE_ASSET', 'health-product-recommender-lite.zip' );
 if ( ! defined( 'HPRL_GITHUB_TOKEN' ) ) {

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -60,6 +60,7 @@ function hprl_quiz_shortcode() {
             $product_data[ $pid ] = array(
                 'img'   => $img ? $img : '',
                 'price' => $prod->get_price_html(),
+                'name'  => $prod->get_name(),
             );
         }
     }
@@ -115,20 +116,28 @@ function hprl_quiz_shortcode() {
             <p>Preporucujemo sledece proizvode:</p>
             <div class="hprl-products">
                 <?php
-                $cheap_data   = isset( $product_data[ $products['cheap'] ] ) ? $product_data[ $products['cheap'] ] : array( 'img' => '', 'price' => '' );
-                $premium_data = isset( $product_data[ $products['premium'] ] ) ? $product_data[ $products['premium'] ] : array( 'img' => '', 'price' => '' );
+                $cheap_data   = isset( $product_data[ $products['cheap'] ] ) ? $product_data[ $products['cheap'] ] : array( 'img' => '', 'price' => '', 'name' => '' );
+                $premium_data = isset( $product_data[ $products['premium'] ] ) ? $product_data[ $products['premium'] ] : array( 'img' => '', 'price' => '', 'name' => '' );
                 ?>
                 <button class="hprl-select" data-type="cheap" data-product="<?php echo esc_attr( $products['cheap'] ); ?>">
                     <?php if ( $cheap_data['img'] ) : ?>
                         <img src="<?php echo esc_url( $cheap_data['img'] ); ?>" alt="">
                     <?php endif; ?>
+                    <?php if ( $cheap_data['name'] ) : ?>
+                        <span class="hprl-name"><?php echo esc_html( $cheap_data['name'] ); ?></span>
+                    <?php endif; ?>
                     <span class="hprl-price"><?php echo wp_kses_post( $cheap_data['price'] ); ?></span>
+                    <span class="hprl-label">Pakovanje za mesec dana</span>
                 </button>
                 <button class="hprl-select" data-type="premium" data-product="<?php echo esc_attr( $products['premium'] ); ?>">
                     <?php if ( $premium_data['img'] ) : ?>
                         <img src="<?php echo esc_url( $premium_data['img'] ); ?>" alt="">
                     <?php endif; ?>
+                    <?php if ( $premium_data['name'] ) : ?>
+                        <span class="hprl-name"><?php echo esc_html( $premium_data['name'] ); ?></span>
+                    <?php endif; ?>
                     <span class="hprl-price"><?php echo wp_kses_post( $premium_data['price'] ); ?></span>
+                    <span class="hprl-label">Jeftinija cena za dužu upotrebu</span>
                 </button>
             </div>
             <div id="hprl-note" class="hprl-note" style="display:none;"></div>

--- a/health-product-recommender-lite/readme.txt
+++ b/health-product-recommender-lite/readme.txt
@@ -3,7 +3,7 @@ Contributors: BeoHosting
 Tags: quiz, health, recommendations
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.4.0
+Stable tag: 1.4.1
 License: GPL2+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -42,3 +42,6 @@ Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnov
 = 1.4.0 =
 * Form now separates first and last name fields.
 * Buttons styled with dark green color.
+
+= 1.4.1 =
+* Display product titles and package notes on results screen.


### PR DESCRIPTION
## Summary
- show product names in results
- include package info messages
- update plugin version to 1.4.1

## Testing
- `php -l health-product-recommender-lite/includes/shortcodes.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842a37693b88322b2d26b81898b7193