### PR TITLE
Improve styling for recommendations

### DIFF
--- a/health-product-recommender-lite/assets/css/style.css
+++ b/health-product-recommender-lite/assets/css/style.css
@@ -3,11 +3,14 @@
 #hprl-quiz input{width:100%;padding:8px;box-sizing:border-box;}
 #hprl-quiz button{padding:10px 20px;margin-top:10px;cursor:pointer;}
 .hprl-products{display:flex;gap:10px;flex-wrap:wrap;}
+.hprl-products .hprl-select{flex:1 1 calc(50% - 10px);text-align:center;}
 @media(max-width:600px){.hprl-products{flex-direction:column;}}
 .hprl-error{color:red;font-size:.9em;display:none;}
 #hprl-quiz .hprl-select img{max-width:120px;display:block;margin:0 auto 5px;}
-#hprl-quiz .hprl-name{display:block;font-weight:bold;margin-top:5px;}
+#hprl-quiz .hprl-name{display:block;font-weight:bold;margin-top:5px;font-size:18px;}
 #hprl-quiz .hprl-price{display:block;margin-top:5px;}
+#hprl-quiz .hprl-results-title{font-size:20px;font-weight:bold;}
+#hprl-quiz .hprl-select[data-type="premium"] .hprl-price{font-size:0.9em;}
 #hprl-quiz .hprl-label{display:block;font-size:.9em;color:#555;}
 #hprl-debug-log{background:#f5f5f5;padding:10px;border:1px solid #ccc;white-space:pre-wrap;}
 .hprl-note{background:#e6f4ea;border-left:5px solid #3aa15c;padding:10px;margin-top:15px;border-radius:4px;color:#2f5d3c;}

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -113,7 +113,7 @@ function hprl_quiz_shortcode() {
         </div>
         <?php endforeach; $step++; ?>
         <div class="hprl-step" data-step="<?php echo $step; ?>" style="display:none;">
-            <p>Preporucujemo sledece proizvode:</p>
+            <p class="hprl-results-title">Preporucujemo sledece proizvode:</p>
             <div class="hprl-products">
                 <?php
                 $cheap_data   = isset( $product_data[ $products['cheap'] ] ) ? $product_data[ $products['cheap'] ] : array( 'img' => '', 'price' => '', 'name' => '' );


### PR DESCRIPTION
## Summary
- add class on results heading
- style responsive recommendation buttons
- increase font size for heading and product names
- slightly shrink VIP price text

## Testing
- `bash -lc 'ls -al health-product-recommender-lite/assets/css/style.css | head'`


------
https://chatgpt.com/codex/tasks/task_b_6842a8002f0483229409924e4027d0bb