### PR TITLE
Add back navigation and mobile scroll fix

### DIFF
--- a/health-product-recommender-lite/assets/css/style.css
+++ b/health-product-recommender-lite/assets/css/style.css
@@ -16,6 +16,8 @@
 .hprl-note{background:#e6f4ea;border-left:5px solid #3aa15c;padding:10px;margin-top:15px;border-radius:4px;color:#2f5d3c;}
 #hprl-quiz .hprl-next{background:rgba(0,88,64,1);color:#fff;padding:12px 24px;font-size:16px;border:none;border-radius:4px;}
 #hprl-quiz .hprl-next:hover{background:rgba(0,88,64,0.8);}
+#hprl-quiz .hprl-prev{background:#ccc;color:#000;padding:12px 24px;font-size:16px;border:none;border-radius:4px;margin-right:10px;}
+#hprl-quiz .hprl-prev:hover{background:#bbb;}
 .hprl-question-group{margin-bottom:15px;}
 .hprl-question-group p{margin-bottom:8px;font-weight:bold;}
 .hprl-question-group label.hprl-answer{display:inline-block;margin-right:10px;margin-bottom:10px;}

--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -103,6 +103,7 @@ document.addEventListener('DOMContentLoaded',function(){
     currentStep=index;
     steps.forEach((s,i)=>{s.style.display=i===index?'block':'none';});
     saveState();
+    window.scrollTo({top:quiz.offsetTop,behavior:'smooth'});
   }
   function clearErrors(scope){
     scope.querySelectorAll('.hprl-error').forEach(e=>{e.textContent='';e.style.display='none';});
@@ -216,6 +217,14 @@ document.addEventListener('DOMContentLoaded',function(){
           .catch(()=>{alert('Greška pri snimanju.');showDebug('Network error');});
       }
       showStep(next-1);
+    });
+  });
+  quiz.querySelectorAll('.hprl-prev').forEach(btn=>{
+    btn.addEventListener('click',function(){
+      const stepElem=this.closest('.hprl-step');
+      const step=parseInt(stepElem.dataset.step);
+      const prev=step-1;
+      showStep(prev-1);
     });
   });
   quiz.querySelectorAll('.hprl-select').forEach(btn=>{

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -109,6 +109,7 @@ function hprl_quiz_shortcode() {
                     <span class="hprl-error"></span>
                 </div>
             <?php $q_index++; endforeach; ?>
+            <button class="hprl-prev">Nazad</button>
             <button class="hprl-next">Dalje</button>
         </div>
         <?php endforeach; $step++; ?>
@@ -141,6 +142,7 @@ function hprl_quiz_shortcode() {
                 </button>
             </div>
             <div id="hprl-note" class="hprl-note" style="display:none;"></div>
+            <button class="hprl-prev">Nazad</button>
         </div>
         <div id="hprl-debug-container" style="display:none;">
             <label><input type="checkbox" id="hprl-debug-toggle"> Prikaži log greške</label>


### PR DESCRIPTION
## Summary
- add `hprl-prev` buttons so users can go back a step
- style the new buttons
- scroll the quiz to the top of the container when changing steps

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_b_6842aebe14d08322822271b8bd08e3e3