### PR TITLE
Enhance purchase UI and fix quiz navigation

### DIFF
--- a/health-product-recommender-lite/assets/css/style.css
+++ b/health-product-recommender-lite/assets/css/style.css
@@ -24,3 +24,5 @@
 .hprl-question-group label.hprl-answer input{display:none;}
 .hprl-question-group label.hprl-answer span{display:block;padding:8px 15px;border:1px solid #ccc;border-radius:4px;background:#f2f2f2;cursor:pointer;transition:background .3s;}
 .hprl-question-group label.hprl-answer input:checked+span{background:rgba(0,88,64,1);color:#fff;border-color:rgba(0,88,64,1);}
+#hprl-quiz .hprl-buy-now{display:inline-block;background:rgba(0,88,64,1);color:#fff;padding:8px 16px;border-radius:4px;margin-top:10px;font-size:16px;}
+#hprl-quiz .hprl-buy-now:hover{background:rgba(0,88,64,0.8);}

--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -103,7 +103,7 @@ document.addEventListener('DOMContentLoaded',function(){
     currentStep=index;
     steps.forEach((s,i)=>{s.style.display=i===index?'block':'none';});
     saveState();
-    window.scrollTo({top:quiz.offsetTop,behavior:'smooth'});
+    steps[index].scrollIntoView({behavior:'smooth',block:'start'});
   }
   function clearErrors(scope){
     scope.querySelectorAll('.hprl-error').forEach(e=>{e.textContent='';e.style.display='none';});

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -129,6 +129,7 @@ function hprl_quiz_shortcode() {
                     <?php endif; ?>
                     <span class="hprl-price"><?php echo wp_kses_post( $cheap_data['price'] ); ?></span>
                     <span class="hprl-label">Pakovanje za mesec dana</span>
+                    <span class="hprl-buy-now">Kupi sada</span>
                 </button>
                 <button class="hprl-select" data-type="premium" data-product="<?php echo esc_attr( $products['premium'] ); ?>">
                     <?php if ( $premium_data['img'] ) : ?>
@@ -139,6 +140,7 @@ function hprl_quiz_shortcode() {
                     <?php endif; ?>
                     <span class="hprl-price"><?php echo wp_kses_post( $premium_data['price'] ); ?></span>
                     <span class="hprl-label">Jeftinija cena za dužu upotrebu</span>
+                    <span class="hprl-buy-now">Kupi sada</span>
                 </button>
             </div>
             <div id="hprl-note" class="hprl-note" style="display:none;"></div>


### PR DESCRIPTION
## Summary
- add a visible **Kupi sada** button inside each product card
- smooth scroll to the top of the next step when navigating
- style the new button

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6842b4ce2a64832283969cf9cdc860b4