### PR TITLE
Fix scroll position on quiz steps

### DIFF
--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -104,6 +104,7 @@ document.addEventListener('DOMContentLoaded',function(){
     steps.forEach((s,i)=>{s.style.display=i===index?'block':'none';});
     saveState();
     steps[index].scrollIntoView({behavior:'smooth',block:'start'});
+    window.scrollTo({top:0,behavior:'smooth'});
   }
   function clearErrors(scope){
     scope.querySelectorAll('.hprl-error').forEach(e=>{e.textContent='';e.style.display='none';});

--- a/health-product-recommender-lite/health-product-recommender-lite.php
+++ b/health-product-recommender-lite/health-product-recommender-lite.php
@@ -3,7 +3,7 @@
 Plugin Name: Health Product Recommender Lite
 Plugin URI: https://beohosting.com/plugins/health-product-recommender-lite
 Description: Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnovu zdravstvenog upitnika, potpuno kompatibilan sa Woodmart temom i Elementorom.
-Version: 1.4.1
+Version: 1.4.2
 Author: BeoHosting
 Author URI: https://beohosting.com
 License: GPL2+
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 define( 'HPRL_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HPRL_URL', plugin_dir_url( __FILE__ ) );
-define( 'HPRL_VERSION', '1.4.1' );
+define( 'HPRL_VERSION', '1.4.2' );
 define( 'HPRL_UPDATE_REPO', 'beopop/eliksir' );
 define( 'HPRL_UPDATE_ASSET', 'health-product-recommender-lite.zip' );
 if ( ! defined( 'HPRL_GITHUB_TOKEN' ) ) {

--- a/health-product-recommender-lite/readme.txt
+++ b/health-product-recommender-lite/readme.txt
@@ -3,7 +3,7 @@ Contributors: BeoHosting
 Tags: quiz, health, recommendations
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.4.1
+Stable tag: 1.4.2
 License: GPL2+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -45,3 +45,6 @@ Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnov
 
 = 1.4.1 =
 * Display product titles and package notes on results screen.
+
+= 1.4.2 =
+* Navigating between quiz pages now scrolls to the top of the page.


### PR DESCRIPTION
## Summary
- ensure moving between quiz steps scrolls to the top
- bump plugin version to 1.4.2
- document update in readme

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842c0cf926c8322842d03950e6e8065