### PR TITLE
Update plugin logic for new product recommendation system

### DIFF
--- a/health-product-recommender-lite/health-product-recommender-lite.php
+++ b/health-product-recommender-lite/health-product-recommender-lite.php
@@ -3,7 +3,7 @@
 Plugin Name: Health Product Recommender Lite
 Plugin URI: https://beohosting.com/plugins/health-product-recommender-lite
 Description: Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnovu zdravstvenog upitnika, potpuno kompatibilan sa Woodmart temom i Elementorom.
-Version: 1.4.2
+Version: 1.5.0
 Author: BeoHosting
 Author URI: https://beohosting.com
 License: GPL2+
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 define( 'HPRL_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HPRL_URL', plugin_dir_url( __FILE__ ) );
-define( 'HPRL_VERSION', '1.4.2' );
+define( 'HPRL_VERSION', '1.5.0' );
 define( 'HPRL_UPDATE_REPO', 'beopop/eliksir' );
 define( 'HPRL_UPDATE_ASSET', 'health-product-recommender-lite.zip' );
 if ( ! defined( 'HPRL_GITHUB_TOKEN' ) ) {

--- a/health-product-recommender-lite/includes/admin-panel.php
+++ b/health-product-recommender-lite/includes/admin-panel.php
@@ -54,14 +54,25 @@ function hprl_questions_page() {
         if ( isset( $_POST['question_text'] ) ) {
             foreach ( $_POST['question_text'] as $i => $qt ) {
                 $text = sanitize_text_field( $qt );
-                $ans  = isset( $_POST['question_answers'][$i] ) ? sanitize_text_field( $_POST['question_answers'][$i] ) : '';
+                $ans  = isset( $_POST['question_answers'][ $i ] ) ? sanitize_text_field( $_POST['question_answers'][ $i ] ) : '';
                 $answers = array();
                 if ( $ans !== '' ) {
-                    $parts = array_map( 'trim', explode( ',', $ans ) );
+                    $parts   = array_map( 'trim', explode( ',', $ans ) );
                     $answers = array_map( 'sanitize_text_field', $parts );
                 }
+                $main    = isset( $_POST['question_main'][ $i ] ) ? intval( $_POST['question_main'][ $i ] ) : 0;
+                $extra   = isset( $_POST['question_extra'][ $i ] ) ? intval( $_POST['question_extra'][ $i ] ) : 0;
+                $package = isset( $_POST['question_package'][ $i ] ) ? intval( $_POST['question_package'][ $i ] ) : 0;
+                $note    = isset( $_POST['question_note'][ $i ] ) ? wp_kses_post( $_POST['question_note'][ $i ] ) : '';
                 if ( $text !== '' ) {
-                    $questions[] = array( 'text' => $text, 'answers' => $answers );
+                    $questions[] = array(
+                        'text'    => $text,
+                        'answers' => $answers,
+                        'main'    => $main,
+                        'extra'   => $extra,
+                        'package' => $package,
+                        'note'    => $note,
+                    );
                 }
             }
         }
@@ -71,82 +82,44 @@ function hprl_questions_page() {
         $per_page = max( 1, intval( $_POST['questions_per_page'] ) );
         update_option( 'hprl_questions_per_page', $per_page );
 
-        $products['cheap']   = intval( $_POST['cheap_product'] );
-        $products['premium'] = intval( $_POST['premium_product'] );
-        update_option( 'hprl_products', $products );
-
         $debug_log = isset( $_POST['hprl_debug_log'] ) ? 1 : 0;
         update_option( 'hprl_debug_log', $debug_log );
 
         $github_token = isset( $_POST['github_token'] ) ? sanitize_text_field( $_POST['github_token'] ) : '';
         update_option( 'hprl_github_token', $github_token );
 
-        $combos = array();
-        if ( isset( $_POST['combo_cheap'] ) ) {
-            $count_c = count( $_POST['combo_cheap'] );
-            for ( $i = 0; $i < $count_c; $i++ ) {
-                $answers = array();
-                $empty = true;
-                for ( $q = 0; $q < $max_q; $q++ ) {
-                    $vals = isset( $_POST["combo_q{$q}"][$i] ) ? (array) $_POST["combo_q{$q}"][$i] : array();
-                    $vals = array_map( 'intval', array_filter( $vals, 'strlen' ) );
-                    if ( ! empty( $vals ) ) {
-                        $empty = false;
-                    }
-                    $answers[] = $vals;
-                }
-                if ( $empty ) {
-                    continue;
-                }
-                $note = isset( $_POST['combo_note'][ $i ] ) ? wp_kses_post( $_POST['combo_note'][ $i ] ) : '';
-                $combos[] = array(
-                    'answers' => $answers,
-                    'cheap'   => intval( $_POST['combo_cheap'][ $i ] ),
-                    'premium' => intval( $_POST['combo_premium'][ $i ] ),
-                    'note'    => $note,
-                );
-            }
-        }
-        update_option( 'hprl_combos', $combos );
+        $universal = isset( $_POST['universal_package'] ) ? intval( $_POST['universal_package'] ) : 0;
+        update_option( 'hprl_universal_package', $universal );
 
         echo '<div class="updated"><p>Sačuvano.</p></div>';
     }
 
     $default_questions = array(
-        array( 'text' => 'Koliko cesto osecate umor?', 'answers' => array( 'Retko', 'Ponekad', 'Cesto' ) ),
-        array( 'text' => 'Da li imate problema sa varenjem?', 'answers' => array( 'Da', 'Ne' ) ),
+        array(
+            'text'    => 'Primer pitanja 1',
+            'answers' => array( 'Da', 'Ne' ),
+            'main'    => 0,
+            'extra'   => 0,
+            'package' => 0,
+            'note'    => ''
+        ),
     );
     $questions = get_option( 'hprl_questions', $default_questions );
-    $products  = get_option( 'hprl_products', array( 'cheap' => '', 'premium' => '' ) );
-    $combos    = get_option( 'hprl_combos', array() );
+    $products  = get_option( 'hprl_products', array() );
     $debug_log = intval( get_option( 'hprl_debug_log', 0 ) );
     $github_token = get_option( 'hprl_github_token', '' );
+    $universal_package = intval( get_option( 'hprl_universal_package', 0 ) );
     $per_page  = intval( get_option( 'hprl_questions_per_page', 3 ) );
     $max_q = count( $questions );
-    foreach ( $combos as &$c ) {
-        if ( ! is_array( $c['answers'] ) ) {
-            $parts = array_pad( explode( '|', $c['answers'] ), $max_q, '' );
-            $new = array();
-            foreach ( $parts as $p ) {
-                $new[] = ( $p === '' ) ? array() : array( intval( $p ) );
-            }
-            $c['answers'] = $new;
-        }
-        if ( ! isset( $c['note'] ) ) {
-            $c['note'] = '';
-        }
-    }
-    unset( $c );
-    if ( empty( $combos ) || ( isset( $combos[0]['answers'] ) && count( $combos[0]['answers'] ) !== $max_q ) ) {
-        $combos = hprl_generate_all_combos( $questions );
-        update_option( 'hprl_combos', $combos );
-    }
-    $max_c = count( $combos );
 
     $all_products = array();
     $prod_posts = get_posts( array( 'post_type' => 'product', 'numberposts' => -1, 'orderby' => 'title', 'order' => 'ASC' ) );
     foreach ( $prod_posts as $p ) {
         $all_products[ $p->ID ] = $p->post_title;
+    }
+    $options_html = '<option value="">-</option>';
+    foreach ( $all_products as $pid => $title ) {
+        $options_html .= '<option value="' . esc_attr( $pid ) . '">' . esc_html( $title ) . '</option>';
     }
     ?>
     <div class="wrap">
@@ -164,8 +137,44 @@ function hprl_questions_page() {
                     <td>
                         <input type="text" name="question_text[<?php echo $i; ?>]" value="<?php echo esc_attr( $q['text'] ); ?>" class="regular-text" />
                         <br/>
-                        <small>Odgovori (zarezom odvojeni)</small><br/>
+                        <small>Odgovori (zarezom odvojeni, prvo "Da" pa "Ne")</small><br/>
                         <input type="text" name="question_answers[<?php echo $i; ?>]" value="<?php echo esc_attr( $ans ); ?>" class="regular-text" />
+                        <br/>
+                        <small>Glavni proizvod</small><br/>
+                        <select name="question_main[<?php echo $i; ?>]">
+                            <option value="">-</option>
+                            <?php foreach ( $all_products as $pid => $title ) : ?>
+                                <option value="<?php echo esc_attr( $pid ); ?>" <?php selected( isset( $q['main'] ) && intval( $q['main'] ) === $pid ); ?>><?php echo esc_html( $title ); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <br/>
+                        <small>Dodatni proizvod</small><br/>
+                        <select name="question_extra[<?php echo $i; ?>]">
+                            <option value="">-</option>
+                            <?php foreach ( $all_products as $pid => $title ) : ?>
+                                <option value="<?php echo esc_attr( $pid ); ?>" <?php selected( isset( $q['extra'] ) && intval( $q['extra'] ) === $pid ); ?>><?php echo esc_html( $title ); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <br/>
+                        <small>Paket proizvoda</small><br/>
+                        <select name="question_package[<?php echo $i; ?>]">
+                            <option value="">-</option>
+                            <?php foreach ( $all_products as $pid => $title ) : ?>
+                                <option value="<?php echo esc_attr( $pid ); ?>" <?php selected( isset( $q['package'] ) && intval( $q['package'] ) === $pid ); ?>><?php echo esc_html( $title ); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <br/>
+                        <small>Objašnjenje</small><br/>
+                        <?php
+                        $note = isset( $q['note'] ) ? $q['note'] : '';
+                        $eid  = 'question_note_' . $i;
+                        wp_editor( $note, $eid, array(
+                            'textarea_name' => "question_note[$i]",
+                            'teeny'         => true,
+                            'media_buttons' => false,
+                            'textarea_rows' => 3,
+                        ) );
+                        ?>
                     </td>
                 </tr>
                 <?php endfor; ?>
@@ -176,27 +185,16 @@ function hprl_questions_page() {
                 <td><input type="number" name="questions_per_page" value="<?php echo esc_attr( $per_page ); ?>" min="1" class="small-text" /></td>
             </tr>
             <tr>
-                <th>ID jeftinijeg proizvoda (podrazumevano)</th>
+                <th>Univerzalni paket proizvoda</th>
                 <td>
-                    <select name="cheap_product">
-                            <option value="">-</option>
-                            <?php foreach ( $all_products as $pid => $title ) : ?>
-                                <option value="<?php echo esc_attr( $pid ); ?>" <?php selected( intval( $products['cheap'] ) === $pid ); ?>><?php echo esc_html( $title ); ?></option>
-                            <?php endforeach; ?>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <th>ID skupljeg proizvoda (podrazumevano)</th>
-                    <td>
-                        <select name="premium_product">
-                            <option value="">-</option>
-                            <?php foreach ( $all_products as $pid => $title ) : ?>
-                                <option value="<?php echo esc_attr( $pid ); ?>" <?php selected( intval( $products['premium'] ) === $pid ); ?>><?php echo esc_html( $title ); ?></option>
-                            <?php endforeach; ?>
-                        </select>
-                    </td>
-                </tr>
+                    <select name="universal_package">
+                        <option value="">-</option>
+                        <?php foreach ( $all_products as $pid => $title ) : ?>
+                            <option value="<?php echo esc_attr( $pid ); ?>" <?php selected( intval( $universal_package ) === $pid ); ?>><?php echo esc_html( $title ); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </td>
+            </tr>
                 <tr>
                     <th>Prikaži log grešaka</th>
                     <td>
@@ -213,74 +211,28 @@ function hprl_questions_page() {
                 </tbody>
             </table>
             <p><button type="button" id="hprl-add-question" class="button">Dodaj novo pitanje</button></p>
-            <h2>Kombinacije proizvoda</h2>
-            <p class="description">Odaberite odgovore za svako pitanje kako biste definisali kombinaciju.</p>
-            <table class="form-table">
-                <tr>
-                    <th>Kombinacija odgovora</th>
-                    <th>Jeftiniji proizvod</th>
-                    <th>Skuplji proizvod</th>
-                    <th>Objašnjenje</th>
-                </tr>
-                <?php for ( $i = 0; $i < $max_c; $i++ ) :
-                    $c = isset( $combos[ $i ] ) ? $combos[ $i ] : array( 'answers' => array(), 'cheap' => '', 'premium' => '', 'note' => '' );
-                ?>
-                <tr>
-                    <td>
-                        <?php for ( $q = 0; $q < $max_q; $q++ ) :
-                            $current = isset( $c['answers'][ $q ] ) ? (array) $c['answers'][ $q ] : array();
-                            $qdata   = isset( $questions[ $q ] ) ? $questions[ $q ] : array( 'answers' => array() );
-                        ?>
-                        <select name="combo_q<?php echo $q; ?>[<?php echo $i; ?>][]" multiple>
-                            <?php foreach ( $qdata['answers'] as $a_idx => $ans ) : ?>
-                                <option value="<?php echo $a_idx; ?>" <?php selected( in_array( $a_idx, $current ) ); ?>><?php echo esc_html( $ans ); ?></option>
-                            <?php endforeach; ?>
-                        </select>
-                        <?php endfor; ?>
-                    </td>
-                    <td>
-                        <select name="combo_cheap[<?php echo $i; ?>]">
-                            <option value="">-</option>
-                            <?php foreach ( $all_products as $pid => $title ) : ?>
-                                <option value="<?php echo esc_attr( $pid ); ?>" <?php selected( intval( $c['cheap'] ) === $pid ); ?>><?php echo esc_html( $title ); ?></option>
-                            <?php endforeach; ?>
-                        </select>
-                    </td>
-                    <td>
-                        <select name="combo_premium[<?php echo $i; ?>]">
-                            <option value="">-</option>
-                            <?php foreach ( $all_products as $pid => $title ) : ?>
-                                <option value="<?php echo esc_attr( $pid ); ?>" <?php selected( intval( $c['premium'] ) === $pid ); ?>><?php echo esc_html( $title ); ?></option>
-                            <?php endforeach; ?>
-                        </select>
-                    </td>
-                    <td>
-                        <?php
-                        $note = isset( $c['note'] ) ? $c['note'] : '';
-                        $eid  = 'combo_note_' . $i;
-                        wp_editor( $note, $eid, array(
-                            'textarea_name' => "combo_note[$i]",
-                            'teeny'         => true,
-                            'media_buttons' => false,
-                            'textarea_rows' => 3,
-                        ) );
-                        ?>
-                    </td>
-                </tr>
-                <?php endfor; ?>
-            </table>
             <p><input type="submit" name="hprl_save_questions" class="button-primary" value="Sačuvaj"></p>
+            <span id="hprl-products-options" style="display:none;"><?php echo $options_html; ?></span>
         </form>
         <script>
         jQuery(document).ready(function($){
             $('#hprl-add-question').on('click', function(){
                 var index = $('#hprl-questions-body tr').length;
+                var opts = $('#hprl-products-options').html();
                 var row = '<tr>'+
                           '<th>Pitanje '+(index+1)+'</th>'+
                           '<td>'+
                           '<input type="text" name="question_text['+index+']" class="regular-text" />'+
-                          '<br/><small>Odgovori (zarezom odvojeni)</small><br/>'+
+                          '<br/><small>Odgovori (zarezom odvojeni, prvo \\"Da\\" pa \\"Ne\\")</small><br/>'+
                           '<input type="text" name="question_answers['+index+']" class="regular-text" />'+
+                          '<br/><small>Glavni proizvod</small><br/>'+
+                          '<select name="question_main['+index+']">'+opts+'</select>'+
+                          '<br/><small>Dodatni proizvod</small><br/>'+
+                          '<select name="question_extra['+index+']">'+opts+'</select>'+
+                          '<br/><small>Paket proizvoda</small><br/>'+
+                          '<select name="question_package['+index+']">'+opts+'</select>'+
+                          '<br/><small>Objašnjenje</small><br/>'+
+                          '<textarea name="question_note['+index+']" rows="3"></textarea>'+
                           '</td>'+
                           '</tr>';
                 $('#hprl-questions-body').append(row);

--- a/health-product-recommender-lite/readme.txt
+++ b/health-product-recommender-lite/readme.txt
@@ -3,7 +3,7 @@ Contributors: BeoHosting
 Tags: quiz, health, recommendations
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.4.2
+Stable tag: 1.5.0
 License: GPL2+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/health-product-recommender-lite/uninstall.php
+++ b/health-product-recommender-lite/uninstall.php
@@ -6,5 +6,5 @@ $wpdb->query( "DROP TABLE IF EXISTS " . $wpdb->prefix . 'health_quiz_results' );
 
 delete_option( 'hprl_questions' );
 delete_option( 'hprl_products' );
-delete_option( 'hprl_combos' );
+delete_option( 'hprl_universal_package' );
 delete_option( 'hprl_github_token' );


### PR DESCRIPTION
## Summary
- refactor quiz logic to use per-question product assignments
- compute recommendations based on "Da" answers only
- show explanation list and three product suggestions (main, extra, package)
- simplify admin panel to configure products per question and universal package
- bump version to 1.5.0

## Testing
- `php -l health-product-recommender-lite.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68502c2d82d483229e8953db3ca892ce