### PR TITLE
Improve recommendation layout

### DIFF
--- a/health-product-recommender-lite/assets/css/style.css
+++ b/health-product-recommender-lite/assets/css/style.css
@@ -26,3 +26,4 @@
 .hprl-question-group label.hprl-answer input:checked+span{background:rgba(0,88,64,1);color:#fff;border-color:rgba(0,88,64,1);}
 #hprl-quiz .hprl-buy-now{display:inline-block;background:rgba(0,88,64,1);color:#fff;padding:8px 16px;border-radius:4px;margin-top:10px;font-size:16px;}
 #hprl-quiz .hprl-buy-now:hover{background:rgba(0,88,64,0.8);}
+.hprl-desc{margin-top:10px;font-size:.9em;color:#333;}

--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -32,23 +32,42 @@ document.addEventListener('DOMContentLoaded',function(){
   function updateProductInfo(type,id){
     const btn=quiz.querySelector('.hprl-select[data-type="'+type+'"]');
     if(!btn) return;
-    btn.dataset.product=id;
-    if(hprlData.products&&hprlData.products[id]){
-      const info=hprlData.products[id];
-      const img=btn.querySelector('img');
-      if(img){
-        if(info.img){img.src=info.img;img.style.display='';}else{img.style.display='none';}
-      }
-      const price=btn.querySelector('.hprl-price');
-      if(price) price.innerHTML=info.price;
-      const nameEl=btn.querySelector('.hprl-name');
-      if(nameEl) nameEl.textContent=info.name;
+    if(!id || !hprlData.products || !hprlData.products[id]){
+      btn.style.display='none';
+      return;
     }
+    btn.style.display='flex';
+    btn.dataset.product=id;
+    const info=hprlData.products[id];
+    const img=btn.querySelector('img');
+    if(img){
+      if(info.img){img.src=info.img;img.style.display='';}else{img.style.display='none';}
+    }
+    const price=btn.querySelector('.hprl-price');
+    if(price) price.innerHTML=info.price;
+    const nameEl=btn.querySelector('.hprl-name');
+    if(nameEl) nameEl.textContent=info.name;
   }
   function updateExplanations(html){
     if(!explBox) return;
-    if(html){explBox.innerHTML=html;explBox.style.display='block';}else{explBox.style.display='none';}
+    if(html){
+      const first=document.getElementById('hprl-first-name').value.trim();
+      const last=document.getElementById('hprl-last-name').value.trim();
+      const name=(first||last)?(first+' '+last).trim():'';
+      const greeting=name?`Poštovani/a ${name},`:'Poštovani/a,';
+      explBox.innerHTML=greeting+'<br>'+html;
+      explBox.style.display='block';
+    }else{
+      explBox.style.display='none';
+    }
   }
+
+  const allProducts=new Set();
+  hprlData.questions.forEach(q=>{
+    if(q.main) allProducts.add(String(q.main));
+    if(q.extra) allProducts.add(String(q.extra));
+    if(q.package) allProducts.add(String(q.package));
+  });
 
   function applyResults(){
     const yesQuestions=[];
@@ -58,22 +77,33 @@ document.addEventListener('DOMContentLoaded',function(){
     });
     const count={main:{},extra:{},package:{}};
     const notes=[];
+    const mentioned=new Set();
     yesQuestions.forEach(i=>{
       const q=hprlData.questions[i];
       if(!q) return;
       if(q.main) count.main[q.main]=(count.main[q.main]||0)+1;
       if(q.extra) count.extra[q.extra]=(count.extra[q.extra]||0)+1;
       if(q.package) count.package[q.package]=(count.package[q.package]||0)+1;
+      if(q.main) mentioned.add(String(q.main));
+      if(q.extra) mentioned.add(String(q.extra));
+      if(q.package) mentioned.add(String(q.package));
       if(q.note) notes.push(q.note);
     });
     function top(obj){let k=null,m=0;Object.keys(obj).forEach(key=>{if(obj[key]>m){m=obj[key];k=key;}});return k;}
     let main=top(count.main)||'';
     let extra=top(count.extra)||'';
     let pack=top(count.package)||'';
-    if(hprlData.universal){pack=hprlData.universal;}
+    let universal='';
+    if(hprlData.universal){
+      const allMentioned=[...allProducts].every(p=>mentioned.has(String(p)));
+      if(allMentioned){
+        universal=hprlData.universal;
+      }
+    }
     updateProductInfo('main',main);
     updateProductInfo('extra',extra);
     updateProductInfo('package',pack);
+    updateProductInfo('universal',universal);
     updateNote('');
     updateExplanations(notes.join('<br>'));
   }

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -97,12 +97,16 @@ function hprl_quiz_shortcode() {
         </div>
         <?php endforeach; $step++; ?>
         <div class="hprl-step" data-step="<?php echo $step; ?>" style="display:none;">
-            <p class="hprl-results-title">Preporučujemo sledeće proizvode:</p>
+            <h2 class="hprl-results-title">Analiza organizma i savet za poboljšanje vašeg stanja</h2>
+            <div id="hprl-explanations" class="hprl-note" style="display:none;"></div>
+
+            <h2 class="hprl-results-title">Preporučujemo proizvode</h2>
             <div class="hprl-products">
                 <button class="hprl-select" data-type="main" data-product="">
                     <img src="" alt="" style="display:none;">
                     <span class="hprl-name"></span>
                     <span class="hprl-price"></span>
+                    <p class="hprl-desc">Ovo je glavni proizvod zbog analize vašeg organizma koji ga preporučuje.</p>
                     <span class="hprl-label">Glavni proizvod</span>
                     <span class="hprl-buy-now">Kupi sada</span>
                 </button>
@@ -110,6 +114,7 @@ function hprl_quiz_shortcode() {
                     <img src="" alt="" style="display:none;">
                     <span class="hprl-name"></span>
                     <span class="hprl-price"></span>
+                    <p class="hprl-desc">Ovo je dodatni proizvod koji preporučujemo radi bržeg oporavka organizma.</p>
                     <span class="hprl-label">Dodatni proizvod</span>
                     <span class="hprl-buy-now">Kupi sada</span>
                 </button>
@@ -117,12 +122,20 @@ function hprl_quiz_shortcode() {
                     <img src="" alt="" style="display:none;">
                     <span class="hprl-name"></span>
                     <span class="hprl-price"></span>
+                    <p class="hprl-desc">Najeftinije rešenje: kombinacija oba proizvoda u paketu – niža cena.</p>
                     <span class="hprl-label">Paket proizvoda</span>
+                    <span class="hprl-buy-now">Kupi sada</span>
+                </button>
+                <button class="hprl-select" data-type="universal" data-product="" style="display:none;">
+                    <img src="" alt="" style="display:none;">
+                    <span class="hprl-name"></span>
+                    <span class="hprl-price"></span>
+                    <p class="hprl-desc">Uzmite sve proizvode po najboljoj ceni i dajte svom organizmu pravu stvar.</p>
+                    <span class="hprl-label">Univerzalni paket</span>
                     <span class="hprl-buy-now">Kupi sada</span>
                 </button>
             </div>
             <div id="hprl-note" class="hprl-note" style="display:none;"></div>
-            <div id="hprl-explanations" class="hprl-note" style="display:none;"></div>
             <button class="hprl-prev">Nazad</button>
         </div>
         <div id="hprl-debug-container" style="display:none;">


### PR DESCRIPTION
## Summary
- refactor quiz results layout
- always show package product card
- optionally show universal package when all products are mentioned
- add personalized explanations and product descriptions

## Testing
- `php -l health-product-recommender-lite/includes/shortcodes.php` *(fails: command not found)*
- `node --check health-product-recommender-lite/assets/js/script.js`

------
https://chatgpt.com/codex/tasks/task_b_68503b2961c8832285ff15b5f013e820