### PR TITLE
Strip VIP price digits from display

### DIFF
--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -48,6 +48,8 @@ document.addEventListener('DOMContentLoaded',function(){
       let html=info.price||'';
       html=html.replace(/<[^>]*vip[^>]*>.*?<\/[^>]+>/gi,'');
       html=html.replace(/Cena za VIP[\s\S]*$/gi,'');
+      html=html.replace(/\bvip\b[^\d]*\d+[\d.,]*\s*(?:rsd|din|eur|€)?/gi,'');
+      html=html.trim();
       price.innerHTML=html;
     }
     const nameEl=btn.querySelector('.hprl-name');

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -41,7 +41,9 @@ function hprl_quiz_shortcode() {
             $img  = wp_get_attachment_image_url( $prod->get_image_id(), 'medium' );
             $price_html = $prod->get_price_html();
             $price_html = preg_replace( '/<[^>]*vip[^>]*>.*?<\/[^>]+>/i', '', $price_html );
-            $price_html = preg_replace( '/Cena za VIP.*/i', '', $price_html );
+            $price_html = preg_replace( '/Cena za VIP[\s\S]*/i', '', $price_html );
+            $price_html = preg_replace( '/\bvip\b[^\d]*\d+[\d.,]*\s*(?:rsd|din|eur|€)?/i', '', $price_html );
+            $price_html = trim( $price_html );
             $product_data[ $pid ] = array(
                 'img'   => $img ? $img : '',
                 'price' => $price_html,


### PR DESCRIPTION
## Summary
- scrub VIP digits from product prices in PHP shortcode
- do the same when rendering prices via script.js

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_685043783de8832288d9fb670a9722a1