### PR TITLE
Add introductory text block above quiz form

### DIFF
--- a/health-product-recommender-lite/assets/css/style.css
+++ b/health-product-recommender-lite/assets/css/style.css
@@ -31,3 +31,8 @@
 #hprl-quiz .hprl-select[data-type="package"]{border-color:#005840;background:#e6f4ea;box-shadow:0 0 0 2px #005840;}
 #hprl-quiz .hprl-select[data-type="package"] .hprl-label{color:#005840;font-weight:bold;}
 #hprl-explanations .hprl-greeting{font-size:20px;font-weight:bold;display:block;margin-bottom:5px;}
+
+# Intro text styles
+#hprl-quiz .hprl-intro{text-align:center;padding:20px 10px;}
+#hprl-quiz .hprl-intro-title{font-size:24px;font-weight:bold;margin-bottom:5px;}
+#hprl-quiz .hprl-intro-desc{font-size:14px;margin-bottom:20px;}

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -55,6 +55,10 @@ function hprl_quiz_shortcode() {
     <div id="hprl-quiz">
         <?php $step = 1; ?>
         <div class="hprl-step" data-step="<?php echo $step; ?>">
+            <div class="hprl-intro">
+                <div class="hprl-intro-title">Provera stanja vašeg organizma</div>
+                <div class="hprl-intro-desc">Odgovorite na 10 jednostavnih pitanja i dobijte besplatnu analizu, personalizovane savete i prirodnu terapiju za rešavanje uzroka problema.</div>
+            </div>
             <label>Ime*<br>
                 <input type="text" id="hprl-first-name" required>
                 <span class="hprl-error" id="hprl-first-name-error"></span>


### PR DESCRIPTION
## Summary
- add intro markup to the quiz first step
- style intro message with bold title and smaller description

## Testing
- `php -l` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685049e42de8832299751465b1b5e0ba