### PR TITLE
Add completion notice before quiz results

### DIFF
--- a/health-product-recommender-lite/assets/css/style.css
+++ b/health-product-recommender-lite/assets/css/style.css
@@ -36,3 +36,6 @@
 #hprl-quiz .hprl-intro{text-align:center;padding:20px 10px;}
 #hprl-quiz .hprl-intro-title{font-size:24px;font-weight:bold;margin-bottom:5px;}
 #hprl-quiz .hprl-intro-desc{font-size:14px;margin-bottom:20px;}
+
+/* Notice shown after quiz completion */
+.hprl-complete-notice{border:2px solid #ffc107;background:#fff8e1;padding:15px;margin-bottom:20px;text-align:center;font-weight:bold;border-radius:4px;}

--- a/health-product-recommender-lite/assets/js/notify.js
+++ b/health-product-recommender-lite/assets/js/notify.js
@@ -1,0 +1,12 @@
+jQuery(function($){
+  var $notice = $('#hprl-complete-notice');
+  if(!$notice.length) return;
+  $notice.hide();
+  $(document).on('hprlQuizStepChange',function(e,data){
+    if(data && data.currentStep === data.stepCount - 1){
+      $notice.stop(true,true).slideDown();
+    }else{
+      $notice.hide();
+    }
+  });
+});

--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -162,6 +162,10 @@ document.addEventListener('DOMContentLoaded',function(){
     }else{
       history.replaceState({},'',baseUrl);
     }
+    document.dispatchEvent(new CustomEvent('hprlQuizStepChange',{detail:{stepCount:steps.length,currentStep:index}}));
+    if(currentStep===steps.length-1){
+      document.dispatchEvent(new Event('hprlQuizComplete'));
+    }
     saveState();
     steps[index].scrollIntoView({behavior:'smooth',block:'start'});
     window.scrollTo({top:0,behavior:'smooth'});

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -103,6 +103,9 @@ function hprl_quiz_shortcode() {
         </div>
         <?php endforeach; $step++; ?>
         <div class="hprl-step" data-step="<?php echo $step; ?>" style="display:none;">
+            <div id="hprl-complete-notice" class="hprl-complete-notice" style="display:none;">
+                <strong>Ispod se nalazi vaš izveštaj za odgovore kao i proizvodi koje savetujemo za poboljšanje bolesti. U slučaju kupovine bilo kog proizvoda dobijate BESPLATNU konsultaciju od 10 minuta putem telefona sa savetnikom za zdravlje. Inače ova konsultacija košta 1990 RSD ali za Vas je besplatna prilikom kupovine bilo kog proizvoda.</strong>
+            </div>
             <h2 class="hprl-results-title">Analiza organizma i savet za poboljšanje vašeg stanja</h2>
             <div id="hprl-explanations" class="hprl-note" style="display:none;"></div>
 
@@ -152,6 +155,7 @@ function hprl_quiz_shortcode() {
     <?php
     wp_enqueue_style( 'hprl-style', HPRL_URL . 'assets/css/style.css', array(), '1.0' );
     wp_enqueue_script( 'hprl-script', HPRL_URL . 'assets/js/script.js', array(), '1.0', true );
+    wp_enqueue_script( 'hprl-notify', HPRL_URL . 'assets/js/notify.js', array( 'jquery', 'hprl-script' ), '1.0', true );
     wp_localize_script( 'hprl-script', 'hprlData', array(
         'ajaxurl'   => admin_url( 'admin-ajax.php' ),
         'nonce'     => wp_create_nonce( 'hprl_nonce' ),


### PR DESCRIPTION
## Summary
- show a styled message before displaying the results
- display/hide the notice via jQuery when quiz completion event fires
- dispatch custom events from the main quiz script

## Testing
- `node -e "require('./health-product-recommender-lite/assets/js/notify.js');"` *(fails: jQuery is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_6852c920f3608322826b4b60efca4ce1