### PR TITLE
Fix completion notice event and refresh slug

### DIFF
--- a/health-product-recommender-lite/assets/js/notify.js
+++ b/health-product-recommender-lite/assets/js/notify.js
@@ -3,7 +3,11 @@ jQuery(function($){
   if(!$notice.length) return;
   $notice.hide();
   $(document).on('hprlQuizStepChange',function(e,data){
-    if(data && data.currentStep === data.stepCount - 1){
+    // When the event is dispatched as a DOM CustomEvent the payload is in
+    // e.detail or e.originalEvent.detail. Support both cases and the jQuery
+    // trigger format where data is passed as the second argument.
+    var info = data || (e.originalEvent && e.originalEvent.detail) || e.detail;
+    if(info && info.currentStep === info.stepCount - 1){
       $notice.stop(true,true).slideDown();
     }else{
       $notice.hide();

--- a/health-product-recommender-lite/health-product-recommender-lite.php
+++ b/health-product-recommender-lite/health-product-recommender-lite.php
@@ -97,3 +97,14 @@ function hprl_force_auto_update( $update, $item ) {
     }
     return $update;
 }
+
+// Redirects /zavrsena-anketa back to the quiz page so that refreshing the last
+// step doesn't result in a 404 page.
+add_action( 'template_redirect', 'hprl_handle_quiz_refresh' );
+function hprl_handle_quiz_refresh() {
+    if ( is_404() && ! empty( $_SERVER['REQUEST_URI'] ) && strpos( $_SERVER['REQUEST_URI'], 'zavrsena-anketa' ) !== false ) {
+        $base = preg_replace( '#zavrsena-anketa/?$#', '', $_SERVER['REQUEST_URI'] );
+        wp_safe_redirect( home_url( $base ) );
+        exit;
+    }
+}


### PR DESCRIPTION
## Summary
- show completion notice correctly by reading CustomEvent data
- avoid 404 error when refreshing `/zavrsena-anketa` by redirecting back to the quiz page

## Testing
- `node --check health-product-recommender-lite/assets/js/notify.js`
- `node --check health-product-recommender-lite/assets/js/script.js`


------
https://chatgpt.com/codex/tasks/task_b_6852e70323e48322a07834cc9fd8addd