### PR TITLE
Use WP_List_Table for results in admin

### DIFF
--- a/health-product-recommender-lite/includes/admin-panel.php
+++ b/health-product-recommender-lite/includes/admin-panel.php
@@ -244,70 +244,20 @@ function hprl_questions_page() {
 }
 
 function hprl_results_page() {
-    global $wpdb;
-    if ( isset( $_POST['hprl_delete_selected'] ) && ! empty( $_POST['hprl_selected'] ) ) {
-        check_admin_referer( 'hprl_delete_selected' );
-        $ids = array_map( 'intval', (array) $_POST['hprl_selected'] );
-        foreach ( $ids as $id ) {
-            if ( $id > 0 ) {
-                $wpdb->delete( HPRL_TABLE, array( 'id' => $id ) );
-            }
-        }
-        echo '<div class="updated"><p>Obrisani selektovani rezultati.</p></div>';
-    }
-    if ( isset( $_GET['delete'] ) ) {
-        $id = intval( $_GET['delete'] );
-        if ( $id > 0 ) {
-            $wpdb->delete( HPRL_TABLE, array( 'id' => $id ) );
-        }
-    }
-    $results = $wpdb->get_results( "SELECT * FROM " . HPRL_TABLE . " ORDER BY created_at DESC" );
+    require_once HPRL_DIR . 'includes/results-table.php';
+
+    $table = new HPRL_Results_Table();
+    $table->process_bulk_action();
+    $table->prepare_items();
+
     ?>
     <div class="wrap">
-        <h1>Rezultati</h1>
-        <p>
-            <a href="?page=hprl-results&export=1" class="button">Export CSV</a>
-        </p>
+        <h1 class="wp-heading-inline">Rezultati</h1>
+        <a href="?page=hprl-results&export=1" class="page-title-action">Export CSV</a>
         <form method="post">
-            <?php wp_nonce_field( 'hprl_delete_selected' ); ?>
-            <table class="widefat">
-                <thead>
-                <tr>
-                    <th style="width:20px"><input type="checkbox" id="hprl-select-all"></th>
-                    <th>ID</th><th>Ime</th><th>Prezime</th><th>Email</th><th>Telefon</th><th>Godina</th><th>Mesto</th><th>Odgovori</th><th>Proizvod</th><th>Datum</th><th>Akcija</th>
-                </tr>
-                </thead>
-                <tbody>
-                <?php foreach ( $results as $row ) : ?>
-                    <tr>
-                        <td><input type="checkbox" name="hprl_selected[]" value="<?php echo esc_attr( $row->id ); ?>"></td>
-                        <td><?php echo esc_html( $row->id ); ?></td>
-                    <td><?php echo esc_html( $row->first_name ); ?></td>
-                    <td><?php echo esc_html( $row->last_name ); ?></td>
-                    <td><?php echo esc_html( $row->email ); ?></td>
-                    <td><?php echo esc_html( $row->phone ); ?></td>
-                    <td><?php echo esc_html( $row->birth_year ); ?></td>
-                    <td><?php echo esc_html( $row->location ); ?></td>
-                    <?php $ans = maybe_unserialize( $row->answers ); ?>
-                    <?php if ( ! is_array( $ans ) ) $ans = array( $ans ); ?>
-                    <td><?php echo esc_html( implode( ',', $ans ) ); ?></td>
-                    <?php $product_title = $row->product_id ? get_the_title( $row->product_id ) : ''; ?>
-                    <td><?php echo esc_html( $product_title ); ?></td>
-                    <td><?php echo esc_html( $row->created_at ); ?></td>
-                    <td><a href="?page=hprl-results&delete=<?php echo intval( $row->id ); ?>" onclick="return confirm('Obrisati ovaj unos?');">Obriši</a></td>
-                </tr>
-            <?php endforeach; ?>
-            </tbody>
-        </table>
-        <p><input type="submit" name="hprl_delete_selected" class="button" value="Obriši selektovane" onclick="return confirm('Obrisati selektovane unose?');"></p>
+            <?php $table->search_box( 'Pretraga', 'hprl-search' ); ?>
+            <?php $table->display(); ?>
         </form>
     </div>
-    <script>
-    jQuery(function($){
-        $('#hprl-select-all').on('change',function(){
-            $('input[name="hprl_selected[]"]').prop('checked', this.checked);
-        });
-    });
-    </script>
     <?php
 }

--- a/health-product-recommender-lite/includes/results-table.php
+++ b/health-product-recommender-lite/includes/results-table.php
@@ -1,0 +1,165 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'WP_List_Table' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+class HPRL_Results_Table extends WP_List_Table {
+
+    public function __construct() {
+        parent::__construct(
+            array(
+                'singular' => 'hprl_result',
+                'plural'   => 'hprl_results',
+                'ajax'     => false,
+            )
+        );
+    }
+
+    protected function get_columns() {
+        return array(
+            'cb'         => '<input type="checkbox" />',
+            'id'         => 'ID',
+            'first_name' => 'Ime',
+            'last_name'  => 'Prezime',
+            'email'      => 'Email',
+            'phone'      => 'Telefon',
+            'birth_year' => 'Godina',
+            'location'   => 'Mesto',
+            'answers'    => 'Odgovori',
+            'product_id' => 'Proizvod',
+            'created_at' => 'Datum',
+            'actions'    => 'Akcija',
+        );
+    }
+
+    protected function get_sortable_columns() {
+        return array(
+            'id'         => array( 'id', false ),
+            'first_name' => array( 'first_name', false ),
+            'last_name'  => array( 'last_name', false ),
+            'email'      => array( 'email', false ),
+            'phone'      => array( 'phone', false ),
+            'birth_year' => array( 'birth_year', false ),
+            'location'   => array( 'location', false ),
+            'created_at' => array( 'created_at', true ),
+        );
+    }
+
+    protected function get_bulk_actions() {
+        return array(
+            'delete' => 'Obriši',
+        );
+    }
+
+    protected function column_cb( $item ) {
+        return sprintf( '<input type="checkbox" name="hprl_selected[]" value="%d" />', $item['id'] );
+    }
+
+    protected function column_actions( $item ) {
+        $url = wp_nonce_url( add_query_arg( array(
+            'page'   => 'hprl-results',
+            'action' => 'delete',
+            'id'     => $item['id'],
+        ), 'admin.php' ), 'bulk-' . $this->_args['plural'] );
+        return sprintf( '<a href="%s" onclick="return confirm(\'Obrisati ovaj unos?\');">Obriši</a>', esc_url( $url ) );
+    }
+
+    public function column_default( $item, $column_name ) {
+        switch ( $column_name ) {
+            case 'answers':
+                $ans = maybe_unserialize( $item['answers'] );
+                if ( ! is_array( $ans ) ) {
+                    $ans = array( $ans );
+                }
+                return esc_html( implode( ',', $ans ) );
+            case 'product_id':
+                return esc_html( $item['product_title'] );
+            default:
+                return isset( $item[ $column_name ] ) ? esc_html( $item[ $column_name ] ) : '';
+        }
+    }
+
+    public function prepare_items() {
+        global $wpdb;
+
+        $per_page = 20;
+        $search   = isset( $_REQUEST['s'] ) ? trim( wp_unslash( $_REQUEST['s'] ) ) : '';
+        $orderby  = ! empty( $_REQUEST['orderby'] ) ? sanitize_text_field( $_REQUEST['orderby'] ) : 'created_at';
+        $order    = ( ! empty( $_REQUEST['order'] ) && strtolower( $_REQUEST['order'] ) === 'asc' ) ? 'ASC' : 'DESC';
+
+        $sortable = $this->get_sortable_columns();
+        if ( ! array_key_exists( $orderby, $sortable ) ) {
+            $orderby = 'created_at';
+        }
+
+        $where  = '';
+        if ( $search !== '' ) {
+            $like  = '%' . $wpdb->esc_like( $search ) . '%';
+            $where = "WHERE first_name LIKE %s OR last_name LIKE %s OR email LIKE %s";
+        }
+
+        if ( $where ) {
+            $total_items = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT COUNT(*) FROM " . HPRL_TABLE . " $where",
+                    $like,
+                    $like,
+                    $like
+                )
+            );
+        } else {
+            $total_items = $wpdb->get_var( "SELECT COUNT(*) FROM " . HPRL_TABLE );
+        }
+
+        $current_page = $this->get_pagenum();
+        $offset = ( $current_page - 1 ) * $per_page;
+
+        if ( $where ) {
+            $sql = $wpdb->prepare(
+                "SELECT * FROM " . HPRL_TABLE . " $where ORDER BY $orderby $order LIMIT %d OFFSET %d",
+                $like,
+                $like,
+                $like,
+                $per_page,
+                $offset
+            );
+        } else {
+            $sql = $wpdb->prepare( "SELECT * FROM " . HPRL_TABLE . " ORDER BY $orderby $order LIMIT %d OFFSET %d", $per_page, $offset );
+        }
+
+        $items = $wpdb->get_results( $sql, ARRAY_A );
+        foreach ( $items as &$it ) {
+            $it['product_title'] = $it['product_id'] ? get_the_title( $it['product_id'] ) : '';
+        }
+
+        $this->items = $items;
+
+        $this->set_pagination_args( array(
+            'total_items' => (int) $total_items,
+            'per_page'    => $per_page,
+            'total_pages' => ceil( $total_items / $per_page ),
+        ) );
+    }
+
+    public function process_bulk_action() {
+        if ( 'delete' === $this->current_action() ) {
+            check_admin_referer( 'bulk-' . $this->_args['plural'] );
+            global $wpdb;
+            $ids = array();
+            if ( ! empty( $_REQUEST['hprl_selected'] ) ) {
+                $ids = array_map( 'intval', (array) $_REQUEST['hprl_selected'] );
+            } elseif ( ! empty( $_GET['id'] ) ) {
+                $ids[] = intval( $_GET['id'] );
+            }
+            foreach ( $ids as $id ) {
+                if ( $id > 0 ) {
+                    $wpdb->delete( HPRL_TABLE, array( 'id' => $id ) );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace manual HTML results table with `WP_List_Table`
- add `HPRL_Results_Table` class implementing pagination, search, sorting and bulk delete

## Testing
- `php -l health-product-recommender-lite/includes/results-table.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68594c05b760832285847cd2fd31c0a2