### PR TITLE
Resolve missing results table

### DIFF
--- a/health-product-recommender-lite/includes/admin-panel.php
+++ b/health-product-recommender-lite/includes/admin-panel.php
@@ -255,8 +255,11 @@ function hprl_results_page() {
         <h1 class="wp-heading-inline">Rezultati</h1>
         <a href="?page=hprl-results&export=1" class="page-title-action">Export CSV</a>
         <form method="post">
-            <?php $table->search_box( 'Pretraga', 'hprl-search' ); ?>
-            <?php $table->display(); ?>
+            <?php
+            wp_nonce_field( 'bulk-' . $table->_args['plural'] );
+            $table->search_box( 'Pretraga', 'hprl-search' );
+            $table->display();
+            ?>
         </form>
     </div>
     <?php

--- a/health-product-recommender-lite/includes/results-table.php
+++ b/health-product-recommender-lite/includes/results-table.php
@@ -55,6 +55,10 @@ class HPRL_Results_Table extends WP_List_Table {
         );
     }
 
+    public function no_items() {
+        echo 'Nema rezultata.';
+    }
+
     public function column_cb( $item ) {
         return sprintf( '<input type="checkbox" name="hprl_selected[]" value="%d" />', $item['id'] );
     }


### PR DESCRIPTION
## Summary
- add `no_items()` message for WP_List_Table
- include nonce in admin results page

## Testing
- `php` syntax check **skipped** because PHP isn't installed

------
https://chatgpt.com/codex/tasks/task_b_6859513e109c8322881fdb362c7a5f03