### PR TITLE
Add health status indicator

### DIFF
--- a/health-product-recommender-lite/assets/css/style.css
+++ b/health-product-recommender-lite/assets/css/style.css
@@ -39,3 +39,7 @@
 
 /* Notice shown after quiz completion */
 .hprl-complete-notice{border:2px solid #ffc107;background:#fff8e1;padding:15px;margin-bottom:20px;text-align:center;font-weight:bold;border-radius:4px;}
+.hprl-status{padding:10px;margin-top:15px;border-radius:4px;color:#fff;font-weight:bold;text-align:center;}
+.hprl-status.green{background:#28a745;}
+.hprl-status.orange{background:#fd7e14;}
+.hprl-status.red{background:#dc3545;}

--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded',function(){
   const debugLog=document.getElementById('hprl-debug-log');
   const noteBox=document.getElementById('hprl-note');
   const explBox=document.getElementById('hprl-explanations');
+  const statusBox=document.getElementById('hprl-status');
   if(debugToggle){
     debugToggle.addEventListener('change',()=>{debugLog.style.display=debugToggle.checked?'block':'none';});
   }
@@ -66,6 +67,24 @@ document.addEventListener('DOMContentLoaded',function(){
       explBox.style.display='none';
     }
   }
+  function updateStatus(count){
+    if(!statusBox) return;
+    let level='green';
+    if(count>=7) level='red';
+    else if(count>=4) level='orange';
+    statusBox.className='hprl-status '+level;
+    let texts=hprlData.status_texts||{};
+    let html='';
+    if(level==='green') html=texts.low||'';
+    else if(level==='orange') html=texts.mid||'';
+    else html=texts.high||'';
+    if(html){
+      statusBox.innerHTML=html;
+      statusBox.style.display='block';
+    }else{
+      statusBox.style.display='none';
+    }
+  }
 
   const allProducts=new Set();
   hprlData.questions.forEach(q=>{
@@ -111,6 +130,7 @@ document.addEventListener('DOMContentLoaded',function(){
     updateProductInfo('universal',universal);
     updateNote('');
     updateExplanations(notes.join('<br>'));
+    updateStatus(yesQuestions.length);
   }
   function saveState(){
     try{

--- a/health-product-recommender-lite/health-product-recommender-lite.php
+++ b/health-product-recommender-lite/health-product-recommender-lite.php
@@ -3,7 +3,7 @@
 Plugin Name: Health Product Recommender Lite
 Plugin URI: https://beohosting.com/plugins/health-product-recommender-lite
 Description: Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnovu zdravstvenog upitnika, potpuno kompatibilan sa Woodmart temom i Elementorom.
-Version: 1.5.0
+Version: 1.5.1
 Author: BeoHosting
 Author URI: https://beohosting.com
 License: GPL2+
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 define( 'HPRL_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HPRL_URL', plugin_dir_url( __FILE__ ) );
-define( 'HPRL_VERSION', '1.5.0' );
+define( 'HPRL_VERSION', '1.5.1' );
 define( 'HPRL_UPDATE_REPO', 'beopop/eliksir' );
 define( 'HPRL_UPDATE_ASSET', 'health-product-recommender-lite.zip' );
 if ( ! defined( 'HPRL_GITHUB_TOKEN' ) ) {

--- a/health-product-recommender-lite/includes/admin-panel.php
+++ b/health-product-recommender-lite/includes/admin-panel.php
@@ -109,6 +109,15 @@ function hprl_questions_page() {
         $universal = isset( $_POST['universal_package'] ) ? intval( $_POST['universal_package'] ) : 0;
         update_option( 'hprl_universal_package', $universal );
 
+        $status_low  = isset( $_POST['status_low'] ) ? wp_kses_post( $_POST['status_low'] ) : '';
+        $status_mid  = isset( $_POST['status_mid'] ) ? wp_kses_post( $_POST['status_mid'] ) : '';
+        $status_high = isset( $_POST['status_high'] ) ? wp_kses_post( $_POST['status_high'] ) : '';
+        update_option( 'hprl_status_texts', array(
+            'low'  => $status_low,
+            'mid'  => $status_mid,
+            'high' => $status_high,
+        ) );
+
         echo '<div class="updated"><p>Sačuvano.</p></div>';
     }
 
@@ -127,6 +136,11 @@ function hprl_questions_page() {
     $debug_log = intval( get_option( 'hprl_debug_log', 0 ) );
     $github_token = get_option( 'hprl_github_token', '' );
     $universal_package = intval( get_option( 'hprl_universal_package', 0 ) );
+    $status_texts = get_option( 'hprl_status_texts', array(
+        'low'  => '',
+        'mid'  => '',
+        'high' => '',
+    ) );
     $per_page  = intval( get_option( 'hprl_questions_per_page', 3 ) );
     $max_q = count( $questions );
 
@@ -225,6 +239,18 @@ function hprl_questions_page() {
                         <input type="text" name="github_token" value="<?php echo esc_attr( $github_token ); ?>" class="regular-text" />
                         <br/><small>Personal access token za ažuriranje sa privatnog repozitorijuma</small>
                     </td>
+                </tr>
+                <tr>
+                    <th>Tekst za 0-3 "Da" odgovora</th>
+                    <td><?php wp_editor( $status_texts['low'], 'status_low', array( 'textarea_name' => 'status_low', 'teeny' => true, 'media_buttons' => false, 'textarea_rows' => 3 ) ); ?></td>
+                </tr>
+                <tr>
+                    <th>Tekst za 4-6 "Da" odgovora</th>
+                    <td><?php wp_editor( $status_texts['mid'], 'status_mid', array( 'textarea_name' => 'status_mid', 'teeny' => true, 'media_buttons' => false, 'textarea_rows' => 3 ) ); ?></td>
+                </tr>
+                <tr>
+                    <th>Tekst za 7+ "Da" odgovora</th>
+                    <td><?php wp_editor( $status_texts['high'], 'status_high', array( 'textarea_name' => 'status_high', 'teeny' => true, 'media_buttons' => false, 'textarea_rows' => 3 ) ); ?></td>
                 </tr>
                 </tbody>
             </table>

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -107,6 +107,7 @@ function hprl_quiz_shortcode() {
                 <strong>Ispod se nalazi vaš izveštaj za odgovore kao i proizvodi koje savetujemo za poboljšanje bolesti. U slučaju kupovine bilo kog proizvoda dobijate BESPLATNU konsultaciju od 10 minuta putem telefona sa savetnikom za zdravlje. Inače ova konsultacija košta 1990 RSD ali za Vas je besplatna prilikom kupovine bilo kog proizvoda.</strong>
             </div>
             <h2 class="hprl-results-title">Analiza organizma i savet za poboljšanje vašeg stanja</h2>
+            <div id="hprl-status" class="hprl-status" style="display:none;"></div>
             <div id="hprl-explanations" class="hprl-note" style="display:none;"></div>
 
             <h2 class="hprl-results-title">Preporučujemo proizvode</h2>
@@ -164,7 +165,12 @@ function hprl_quiz_shortcode() {
         'products'  => $product_data,
         'questions' => $questions,
         'universal' => $universal_package,
-        'debug'     => $debug_log
+        'debug'     => $debug_log,
+        'status_texts' => get_option( 'hprl_status_texts', array(
+            'low'  => '',
+            'mid'  => '',
+            'high' => '',
+        ) )
     ) );
     return ob_get_clean();
 }

--- a/health-product-recommender-lite/readme.txt
+++ b/health-product-recommender-lite/readme.txt
@@ -3,7 +3,7 @@ Contributors: BeoHosting
 Tags: quiz, health, recommendations
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 1.5.0
+Stable tag: 1.5.1
 License: GPL2+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -48,3 +48,6 @@ Lagani, responzivni WordPress plugin koji generiše preporuke proizvoda na osnov
 
 = 1.4.2 =
 * Navigating between quiz pages now scrolls to the top of the page.
+
+= 1.5.1 =
+* Dodata vizuelna oznaka nivoa alarmantnosti sa prilagodljivim tekstom.

--- a/health-product-recommender-lite/uninstall.php
+++ b/health-product-recommender-lite/uninstall.php
@@ -8,3 +8,4 @@ delete_option( 'hprl_questions' );
 delete_option( 'hprl_products' );
 delete_option( 'hprl_universal_package' );
 delete_option( 'hprl_github_token' );
+delete_option( 'hprl_status_texts' );


### PR DESCRIPTION
## Summary
- add admin fields for alarm level messages
- show color-coded health indicator on results
- localize status texts to JS and show indicator in script
- bump plugin version to 1.5.1
- document new feature

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_b_6866c304b048832284d192b955b07bc6