### PR TITLE
Add gauge indicator for quiz results

### DIFF
--- a/health-product-recommender-lite/assets/css/style.css
+++ b/health-product-recommender-lite/assets/css/style.css
@@ -43,3 +43,9 @@
 .hprl-status.green{background:#28a745;}
 .hprl-status.orange{background:#fd7e14;}
 .hprl-status.red{background:#dc3545;}
+
+/* Gauge indicator */
+.hprl-gauge{width:150px;height:75px;border:10px solid #ccc;border-bottom:none;border-radius:150px 150px 0 0;position:relative;margin:20px auto;}
+.hprl-gauge-needle{position:absolute;bottom:0;left:50%;width:2px;height:70px;background:#28a745;transform-origin:bottom center;transform:rotate(-60deg);transition:transform .3s ease;}
+.hprl-gauge-needle.orange{background:#fd7e14;transform:rotate(0deg);}
+.hprl-gauge-needle.red{background:#dc3545;transform:rotate(60deg);}

--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -14,6 +14,8 @@ document.addEventListener('DOMContentLoaded',function(){
   const noteBox=document.getElementById('hprl-note');
   const explBox=document.getElementById('hprl-explanations');
   const statusBox=document.getElementById('hprl-status');
+  const gaugeBox=document.getElementById('hprl-gauge');
+  const gaugeNeedle=gaugeBox?gaugeBox.querySelector('.hprl-gauge-needle'):null;
   if(debugToggle){
     debugToggle.addEventListener('change',()=>{debugLog.style.display=debugToggle.checked?'block':'none';});
   }
@@ -68,21 +70,27 @@ document.addEventListener('DOMContentLoaded',function(){
     }
   }
   function updateStatus(count){
-    if(!statusBox) return;
+    if(!statusBox && !gaugeBox) return;
     let level='green';
     if(count>=7) level='red';
     else if(count>=4) level='orange';
-    statusBox.className='hprl-status '+level;
-    let texts=hprlData.status_texts||{};
-    let html='';
-    if(level==='green') html=texts.low||'';
-    else if(level==='orange') html=texts.mid||'';
-    else html=texts.high||'';
-    if(html){
-      statusBox.innerHTML=html;
-      statusBox.style.display='block';
-    }else{
-      statusBox.style.display='none';
+    if(statusBox){
+      statusBox.className='hprl-status '+level;
+      let texts=hprlData.status_texts||{};
+      let html='';
+      if(level==='green') html=texts.low||'';
+      else if(level==='orange') html=texts.mid||'';
+      else html=texts.high||'';
+      if(html){
+        statusBox.innerHTML=html;
+        statusBox.style.display='block';
+      }else{
+        statusBox.style.display='none';
+      }
+    }
+    if(gaugeBox && gaugeNeedle){
+      gaugeBox.style.display='block';
+      gaugeNeedle.className='hprl-gauge-needle '+level;
     }
   }
 

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -108,6 +108,9 @@ function hprl_quiz_shortcode() {
             </div>
             <h2 class="hprl-results-title">Analiza organizma i savet za poboljšanje vašeg stanja</h2>
             <div id="hprl-status" class="hprl-status" style="display:none;"></div>
+            <div id="hprl-gauge" class="hprl-gauge" style="display:none;">
+                <div class="hprl-gauge-needle"></div>
+            </div>
             <div id="hprl-explanations" class="hprl-note" style="display:none;"></div>
 
             <h2 class="hprl-results-title">Preporučujemo proizvode</h2>


### PR DESCRIPTION
## Summary
- show a gauge indicator after completing quiz
- style gauge with needle colours and positions
- update JS logic to control gauge

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6866c80577c483229aabf3f3f78cb634