### PR TITLE
Add gauge headings and thicker needle

### DIFF
--- a/health-product-recommender-lite/assets/css/style.css
+++ b/health-product-recommender-lite/assets/css/style.css
@@ -46,6 +46,12 @@
 
 /* Gauge indicator */
 .hprl-gauge{width:150px;height:75px;border:10px solid #ccc;border-bottom:none;border-radius:150px 150px 0 0;position:relative;margin:20px auto;}
-.hprl-gauge-needle{position:absolute;bottom:0;left:50%;width:2px;height:70px;background:#28a745;transform-origin:bottom center;transform:rotate(-60deg);transition:transform .3s ease;}
+.hprl-gauge-needle{position:absolute;bottom:0;left:50%;width:8px;height:70px;background:#28a745;transform-origin:bottom center;transform:rotate(-60deg);transition:transform .3s ease;}
 .hprl-gauge-needle.orange{background:#fd7e14;transform:rotate(0deg);}
 .hprl-gauge-needle.red{background:#dc3545;transform:rotate(60deg);}
+.hprl-gauge-labels{display:flex;justify-content:space-between;margin-top:5px;font-size:12px;font-weight:bold;}
+.hprl-gauge-labels span{flex:1;text-align:center;}
+.hprl-gauge-labels span:first-child{text-align:left;}
+.hprl-gauge-labels span:last-child{text-align:right;}
+.hprl-gauge-count{text-align:center;margin-top:5px;font-weight:bold;}
+.hprl-overall h3{text-align:center;margin-bottom:5px;}

--- a/health-product-recommender-lite/assets/js/script.js
+++ b/health-product-recommender-lite/assets/js/script.js
@@ -14,8 +14,10 @@ document.addEventListener('DOMContentLoaded',function(){
   const noteBox=document.getElementById('hprl-note');
   const explBox=document.getElementById('hprl-explanations');
   const statusBox=document.getElementById('hprl-status');
+  const gaugeWrapper=document.getElementById('hprl-overall');
   const gaugeBox=document.getElementById('hprl-gauge');
   const gaugeNeedle=gaugeBox?gaugeBox.querySelector('.hprl-gauge-needle'):null;
+  const gaugeCount=document.getElementById('hprl-gauge-count');
   if(debugToggle){
     debugToggle.addEventListener('change',()=>{debugLog.style.display=debugToggle.checked?'block':'none';});
   }
@@ -88,9 +90,13 @@ document.addEventListener('DOMContentLoaded',function(){
         statusBox.style.display='none';
       }
     }
+    if(gaugeWrapper) gaugeWrapper.style.display='block';
     if(gaugeBox && gaugeNeedle){
       gaugeBox.style.display='block';
       gaugeNeedle.className='hprl-gauge-needle '+level;
+    }
+    if(gaugeCount){
+      gaugeCount.textContent='Broj DA odgovora: '+count+'. U odnosu količine DA odgovora ovo je grafikon vašeg stanja organizma.';
     }
   }
 

--- a/health-product-recommender-lite/includes/shortcodes.php
+++ b/health-product-recommender-lite/includes/shortcodes.php
@@ -107,10 +107,19 @@ function hprl_quiz_shortcode() {
                 <strong>Ispod se nalazi vaš izveštaj za odgovore kao i proizvodi koje savetujemo za poboljšanje bolesti. U slučaju kupovine bilo kog proizvoda dobijate BESPLATNU konsultaciju od 10 minuta putem telefona sa savetnikom za zdravlje. Inače ova konsultacija košta 1990 RSD ali za Vas je besplatna prilikom kupovine bilo kog proizvoda.</strong>
             </div>
             <h2 class="hprl-results-title">Analiza organizma i savet za poboljšanje vašeg stanja</h2>
-            <div id="hprl-status" class="hprl-status" style="display:none;"></div>
-            <div id="hprl-gauge" class="hprl-gauge" style="display:none;">
-                <div class="hprl-gauge-needle"></div>
+            <div id="hprl-overall" class="hprl-overall" style="display:none;">
+                <h3>Opšte stanje vašeg organizma</h3>
+                <div id="hprl-gauge" class="hprl-gauge">
+                    <div class="hprl-gauge-needle"></div>
+                </div>
+                <div class="hprl-gauge-labels">
+                    <span>normalno stanje</span>
+                    <span>alarmantno</span>
+                    <span>veoma alarmantno</span>
+                </div>
+                <div id="hprl-gauge-count" class="hprl-gauge-count"></div>
             </div>
+            <div id="hprl-status" class="hprl-status" style="display:none;"></div>
             <div id="hprl-explanations" class="hprl-note" style="display:none;"></div>
 
             <h2 class="hprl-results-title">Preporučujemo proizvode</h2>


### PR DESCRIPTION
## Summary
- enhance gauge by adding overall indicator section
- display yes-answer count for gauge
- add thicker gauge needle and labels in CSS

## Testing
- `php -l health-product-recommender-lite/includes/shortcodes.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866cb5bc7748322b3a2d9857905c797